### PR TITLE
Remove unused includes

### DIFF
--- a/CustomToolButton.h
+++ b/CustomToolButton.h
@@ -2,7 +2,6 @@
 #define CUSTOMTOOLBUTTON_H
 
 #include <QToolButton>
-#include <QDebug>
 
 class CustomToolButton : public QToolButton
 {

--- a/GraphicsItems.cpp
+++ b/GraphicsItems.cpp
@@ -3,6 +3,7 @@
 #include <QCursor>
 #include <QGraphicsSceneMouseEvent>
 #include <QPainterPathStroker>
+#include <QDebug>
 
 GraphicsItems::GraphicsItems()
 {

--- a/GraphicsItems.h
+++ b/GraphicsItems.h
@@ -2,11 +2,11 @@
 #define GRAPHICSITEMS_H
 #include <QGraphicsItem>
 #include <QPainter>
-#include <QDebug>
 #include <QList>
 #include <QtGlobal>
 
 
+class QTextStream;
 
 
 class GraphicsItems : public QGraphicsItem

--- a/MeasureDialog.cpp
+++ b/MeasureDialog.cpp
@@ -8,7 +8,6 @@
 #include <QGuiApplication>
 #include <QSignalBlocker>
 #include <QAction>
-#include <QCloseEvent>
 #include <QScreen>
 #include <QLCDNumber>
 #include <QPalette>

--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -1,13 +1,13 @@
 #include "SettingsDialog.h"
 #include "ui_SettingsDialog.h"
 #include "shortcutsdialog.h"
-#include "ui_shortcutsdialog.h"
 #include <QSerialPortInfo>
-#include <QGraphicsScene>
 #include <QColor>
 #include <QFileDialog>
 #include <QShortcut>
 #include <QKeySequence>
+#include <QSettings>
+#include <QColorDialog>
 #include <QDebug>
 
 

--- a/SettingsDialog.h
+++ b/SettingsDialog.h
@@ -2,11 +2,10 @@
 #define SETTINGSDIALOG_H
 
 #include <QDialog>
-#include <QtCore>
-#include <QDebug>
-#include <QSettings>
-#include <QColorDialog>
-#include <shortcutsdialog.h>
+#include <QColor>
+#include "settings.h"
+
+class QPen;
 
 namespace Ui {
 class SettingsDialog;

--- a/calibrationengine.cpp
+++ b/calibrationengine.cpp
@@ -1,4 +1,5 @@
 #include "calibrationengine.h"
+#include <QDebug>
 
 
 

--- a/calibrationengine.h
+++ b/calibrationengine.h
@@ -2,11 +2,11 @@
 #define CALIBRATIONENGINE_H
 #include <QVector>
 #include <QPointF>
-#include<QLineF>
+#include <QLineF>
 #include <qmath.h>
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <QDebug>
+#include <limits>
 
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,25 +1,17 @@
-#include <QStandardItemModel>
-#include <QStatusBar>
 #include <QDebug>
 #include <QMessageBox>
-#include <QSerialPortInfo>
-#include <QKeyEvent>
-#include <QList>
-#include <QApplication>
 #include <QAction>
-#include <QToolButton>
-#include <QToolBar>
 #include <QGraphicsScene>
-#include <QElapsedTimer>                     //measure time
-#include <QThread>
 #include <QFileDialog>     //save dxf
 #include <QDir>
 #include <QtMath>
 
-#include <QTranslator>
-#include <QInputDialog>
 #include "appmanager.h"
-
+#include "CustomToolButton.h"
+#include "MeasureDialog.h"
+#include "calibratewindow.h"
+#include "InfoDialog.h"
+#include "SettingsDialog.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -4,36 +4,27 @@
 #include <QMainWindow>
 #include <QtCore>
 #include <QtGui>
-#include <QDebug>
-#include <QSettings>
-//#include "my_modbus.h"
-//#include <QModbusDataUnit>
 #include <QSerialPort>
 #include <QGraphicsView>
-#include <QGraphicsItem>
-#include "GraphicsItems.h"
-#include <QThread>
-#include "shortcutsdialog.h"
-#include "CustomToolButton.h"
-#include "MeasureDialog.h"
-#include "calibratewindow.h"
-#include "InfoDialog.h"
-#include <qmath.h>
-#include "appmanager.h"
-#include "QGraphicsItem"
-#include "settingsmanager.h"     // kvůli typu SettingsManager
-#include "SettingsDialog.h"      // kvůli dialogu
-#include "appmanager.h"
+#include "settings.h"
 
-#define _USE_MATH_DEFINES
-#include <cmath>
 
 QT_BEGIN_NAMESPACE
 //class QModbusClient;
 //class QModbusReply;
 class QGraphicsView;
+class QGraphicsItem;
+class QGraphicsLineItem;
+class QGraphicsEllipseItem;
 class AppManager;
 class SettingsManager;
+class CustomToolButton;
+class MeasureDialog;
+class CalibrateWindow;
+class InfoDialog;
+class GraphicsItems;
+class QKeyEvent;
+enum class AddPointMode;
 
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE

--- a/settings.h
+++ b/settings.h
@@ -2,9 +2,9 @@
 #include <QString>
 #include <QKeySequence>
 #include <QHash>
-#include <QDebug>
-#include <QSettings>
-#include <QColorDialog>
+#include <QPen>
+#include <QColor>
+#include <QRect>
 
 // --- Units enum & helpers ---
 enum class Units { Millimeters, Inches };

--- a/settingsmanager.cpp
+++ b/settingsmanager.cpp
@@ -2,6 +2,7 @@
 #include <QCoreApplication>
 #include <QJsonDocument>
 #include <QFile>
+#include <QDebug>
 
 SettingsManager::SettingsManager(QObject* parent)
     : QObject(parent)

--- a/shapemanager.cpp
+++ b/shapemanager.cpp
@@ -1,4 +1,5 @@
 #include "shapemanager.h"
+#include <QDebug>
 
 ShapeManager::ShapeManager(QObject* parent)
     : QObject(parent)

--- a/shortcutsdialog.cpp
+++ b/shortcutsdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_shortcutsdialog.h"      // přesný název podle .ui
 #include <QKeySequenceEdit>
 #include <QPushButton>
+#include <QDebug>
 
 ShortCutsDialog::ShortCutsDialog(QWidget* parent)
     : QDialog(parent),

--- a/shortcutsdialog.h
+++ b/shortcutsdialog.h
@@ -2,7 +2,6 @@
 #define SHORTCUTSDIALOG_H
 
 #include <QDialog>
-#include <QDebug>
 #include "settings.h"                 // kvůli Shortcuts
 
 namespace Ui { class ShortCutsDialog; }


### PR DESCRIPTION
## Summary
- streamline Qt include directives across dialogs and managers
- add missing QDebug headers where qDebug is used
- switch to forward declarations in `MainWindow` to reduce dependencies

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa335d179083289d2efca5ab329add