### PR TITLE
Expand SettingsManager JSON import/export

### DIFF
--- a/settingsmanager.cpp
+++ b/settingsmanager.cpp
@@ -1,6 +1,7 @@
 #include "settingsmanager.h"
 #include <QCoreApplication>
 #include <QJsonDocument>
+#include <QJsonParseError>
 #include <QFile>
 #include <QDebug>
 
@@ -206,16 +207,63 @@ Shortcuts SettingsManager::jsonToShortcuts(const QJsonObject& obj) {
 
 bool SettingsManager::exportJson(const QString& filePath, QString* err) const {
     const Settings& st = current_;
-    QJsonObject root, serial, ui;
+    QJsonObject root, comm, serial, modbus, simulation, ui, program;
 
-    serial[QStringLiteral("PortName")] = st.portName;
-    serial[QStringLiteral("Baud")]     = st.baudRate;
+    // Communication
+    comm[QStringLiteral("DataSource")] = dataSourceToString(st.datasource);
 
-    ui[QStringLiteral("Units")]        = unitsToString(st.units);
+    serial[QStringLiteral("PortName")] = st.serial.portName;
+    serial[QStringLiteral("Baud")]     = st.serial.baudRate;
+    serial[QStringLiteral("DataBits")] = st.serial.dataBits;
+    serial[QStringLiteral("StopBits")] = st.serial.stopBits;
+    serial[QStringLiteral("Parity")]   = st.serial.parity;
+    serial[QStringLiteral("Flow")]     = st.serial.flow;
 
-    root[QStringLiteral("Serial")]    = serial;
-    root[QStringLiteral("UI")]        = ui;
-    root[QStringLiteral("Shortcuts")] = shortcutsToJson(st.shortcuts);
+    modbus[QStringLiteral("IsTcp")]      = st.modbus.isTcp;
+    modbus[QStringLiteral("SerialPort")] = st.modbus.serialPort;
+    modbus[QStringLiteral("Baud")]       = st.modbus.baudRate;
+    modbus[QStringLiteral("Host")]       = st.modbus.host;
+    modbus[QStringLiteral("Port")]       = st.modbus.port;
+    modbus[QStringLiteral("ServerId")]   = st.modbus.serverId;
+
+    simulation[QStringLiteral("LogFile")]     = st.simulation.logFile;
+    simulation[QStringLiteral("SpeedFactor")] = st.simulation.speedFactor;
+
+    ui[QStringLiteral("Units")] = unitsToString(st.units);
+    ui[QStringLiteral("ArmsColor")] = st.arms_color.name(QColor::HexArgb);
+    ui[QStringLiteral("SaveMainWindowPos")] = st.save_main_window_position_on_exit;
+    ui[QStringLiteral("SaveMeasureWindowPos")] = st.save_measure_window_position_on_exit;
+    QJsonObject mainRect, measureRect;
+    mainRect[QStringLiteral("x")] = st.main_window_position.x();
+    mainRect[QStringLiteral("y")] = st.main_window_position.y();
+    mainRect[QStringLiteral("w")] = st.main_window_position.width();
+    mainRect[QStringLiteral("h")] = st.main_window_position.height();
+    measureRect[QStringLiteral("x")] = st.measure_window_position.x();
+    measureRect[QStringLiteral("y")] = st.measure_window_position.y();
+    measureRect[QStringLiteral("w")] = st.measure_window_position.width();
+    measureRect[QStringLiteral("h")] = st.measure_window_position.height();
+    ui[QStringLiteral("MainWindow")] = mainRect;
+    ui[QStringLiteral("MeasureWindow")] = measureRect;
+    ui[QStringLiteral("Language")] = st.language;
+    ui[QStringLiteral("DirectorySaveDxf")] = st.directory_save_dxf;
+    ui[QStringLiteral("DirectorySaveData")] = st.directory_save_data;
+
+    program[QStringLiteral("Arm1Length")]   = st.arm1_length;
+    program[QStringLiteral("Arm2Length")]   = st.arm2_length;
+    program[QStringLiteral("AutoStep")]     = st.auto_step;
+    program[QStringLiteral("AlfaOffset")]   = st.alfa_offset;
+    program[QStringLiteral("BetaOffset")]   = st.beta_offset;
+    program[QStringLiteral("DocumentModified")] = st.document_modified;
+    program[QStringLiteral("DocumentSaved")]    = st.document_saved;
+    program[QStringLiteral("UnitsScale")]  = st.units_scale;
+
+    root[QStringLiteral("Comm")]       = comm;
+    root[QStringLiteral("Serial")]     = serial;
+    root[QStringLiteral("Modbus")]     = modbus;
+    root[QStringLiteral("Simulation")] = simulation;
+    root[QStringLiteral("UI")]         = ui;
+    root[QStringLiteral("Program")]    = program;
+    root[QStringLiteral("Shortcuts")]  = shortcutsToJson(st.shortcuts);
 
     QFile f(filePath);
     if (!f.open(QIODevice::WriteOnly)) { if (err) *err = QStringLiteral("Nelze otevřít k zápisu"); return false; }
@@ -226,20 +274,80 @@ bool SettingsManager::exportJson(const QString& filePath, QString* err) const {
 bool SettingsManager::importJson(const QString& filePath, QString* err) {
     QFile f(filePath);
     if (!f.open(QIODevice::ReadOnly)) { if (err) *err = QStringLiteral("Nelze otevřít k čtení"); return false; }
-    const auto doc = QJsonDocument::fromJson(f.readAll());
+
+    QJsonParseError jsonErr;
+    const auto doc = QJsonDocument::fromJson(f.readAll(), &jsonErr);
+    if (jsonErr.error != QJsonParseError::NoError) {
+        if (err) *err = QStringLiteral("Chyba v syntaxi JSON: %1").arg(jsonErr.errorString());
+        return false;
+    }
     if (!doc.isObject()) { if (err) *err = QStringLiteral("Neplatný JSON"); return false; }
 
     const QJsonObject root = doc.object();
 
+    if (root.contains(QStringLiteral("Comm"))) {
+        const auto o = root.value(QStringLiteral("Comm")).toObject();
+        current_.datasource = stringToDataSource(o.value(QStringLiteral("DataSource")).toString(dataSourceToString(current_.datasource)));
+    }
     if (root.contains(QStringLiteral("Serial"))) {
         const auto o = root.value(QStringLiteral("Serial")).toObject();
-        current_.portName = o.value(QStringLiteral("PortName")).toString(current_.portName);
-        current_.baudRate = o.value(QStringLiteral("Baud")).toInt(current_.baudRate);
+        current_.serial.portName = o.value(QStringLiteral("PortName")).toString(current_.serial.portName);
+        current_.serial.baudRate = o.value(QStringLiteral("Baud")).toInt(current_.serial.baudRate);
+        current_.serial.dataBits = o.value(QStringLiteral("DataBits")).toInt(current_.serial.dataBits);
+        current_.serial.stopBits = o.value(QStringLiteral("StopBits")).toInt(current_.serial.stopBits);
+        current_.serial.parity   = o.value(QStringLiteral("Parity")).toInt(current_.serial.parity);
+        current_.serial.flow     = o.value(QStringLiteral("Flow")).toInt(current_.serial.flow);
+        current_.portName = current_.serial.portName;
+        current_.baudRate = current_.serial.baudRate;
+    }
+    if (root.contains(QStringLiteral("Modbus"))) {
+        const auto o = root.value(QStringLiteral("Modbus")).toObject();
+        current_.modbus.isTcp      = o.value(QStringLiteral("IsTcp")).toBool(current_.modbus.isTcp);
+        current_.modbus.serialPort = o.value(QStringLiteral("SerialPort")).toString(current_.modbus.serialPort);
+        current_.modbus.baudRate   = o.value(QStringLiteral("Baud")).toInt(current_.modbus.baudRate);
+        current_.modbus.host       = o.value(QStringLiteral("Host")).toString(current_.modbus.host);
+        current_.modbus.port       = o.value(QStringLiteral("Port")).toInt(current_.modbus.port);
+        current_.modbus.serverId   = o.value(QStringLiteral("ServerId")).toInt(current_.modbus.serverId);
+    }
+    if (root.contains(QStringLiteral("Simulation"))) {
+        const auto o = root.value(QStringLiteral("Simulation")).toObject();
+        current_.simulation.logFile     = o.value(QStringLiteral("LogFile")).toString(current_.simulation.logFile);
+        current_.simulation.speedFactor = o.value(QStringLiteral("SpeedFactor")).toDouble(current_.simulation.speedFactor);
     }
     if (root.contains(QStringLiteral("UI"))) {
         const auto o = root.value(QStringLiteral("UI")).toObject();
-        current_.units = stringToUnits(o.value(QStringLiteral("Units"))
-                                       .toString(unitsToString(current_.units)));
+        current_.units = stringToUnits(o.value(QStringLiteral("Units")).toString(unitsToString(current_.units)));
+        current_.arms_color = QColor(o.value(QStringLiteral("ArmsColor")).toString(current_.arms_color.name()));
+        current_.save_main_window_position_on_exit = o.value(QStringLiteral("SaveMainWindowPos")).toBool(current_.save_main_window_position_on_exit);
+        current_.save_measure_window_position_on_exit = o.value(QStringLiteral("SaveMeasureWindowPos")).toBool(current_.save_measure_window_position_on_exit);
+        if (o.contains(QStringLiteral("MainWindow"))) {
+            const auto r = o.value(QStringLiteral("MainWindow")).toObject();
+            current_.main_window_position = QRect(r.value(QStringLiteral("x")).toInt(),
+                                                 r.value(QStringLiteral("y")).toInt(),
+                                                 r.value(QStringLiteral("w")).toInt(),
+                                                 r.value(QStringLiteral("h")).toInt());
+        }
+        if (o.contains(QStringLiteral("MeasureWindow"))) {
+            const auto r = o.value(QStringLiteral("MeasureWindow")).toObject();
+            current_.measure_window_position = QRect(r.value(QStringLiteral("x")).toInt(),
+                                                    r.value(QStringLiteral("y")).toInt(),
+                                                    r.value(QStringLiteral("w")).toInt(),
+                                                    r.value(QStringLiteral("h")).toInt());
+        }
+        current_.language = o.value(QStringLiteral("Language")).toString(current_.language);
+        current_.directory_save_dxf = o.value(QStringLiteral("DirectorySaveDxf")).toString(current_.directory_save_dxf);
+        current_.directory_save_data = o.value(QStringLiteral("DirectorySaveData")).toString(current_.directory_save_data);
+    }
+    if (root.contains(QStringLiteral("Program"))) {
+        const auto o = root.value(QStringLiteral("Program")).toObject();
+        current_.arm1_length   = o.value(QStringLiteral("Arm1Length")).toDouble(current_.arm1_length);
+        current_.arm2_length   = o.value(QStringLiteral("Arm2Length")).toDouble(current_.arm2_length);
+        current_.auto_step     = o.value(QStringLiteral("AutoStep")).toDouble(current_.auto_step);
+        current_.alfa_offset   = o.value(QStringLiteral("AlfaOffset")).toDouble(current_.alfa_offset);
+        current_.beta_offset   = o.value(QStringLiteral("BetaOffset")).toDouble(current_.beta_offset);
+        current_.document_modified = o.value(QStringLiteral("DocumentModified")).toBool(current_.document_modified);
+        current_.document_saved    = o.value(QStringLiteral("DocumentSaved")).toBool(current_.document_saved);
+        current_.units_scale   = o.value(QStringLiteral("UnitsScale")).toDouble(current_.units_scale);
     }
     if (root.contains(QStringLiteral("Shortcuts"))) {
         current_.shortcuts = jsonToShortcuts(root.value(QStringLiteral("Shortcuts")).toObject());


### PR DESCRIPTION
## Summary
- export additional settings fields (communication, UI, program) to JSON
- import additional fields and propagate them to runtime settings
- add basic JSON syntax validation on import

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3bcb2dd48328a4510d73270713db