### PR TITLE
Use environment variables for user-independent settings

### DIFF
--- a/settingsmanager.h
+++ b/settingsmanager.h
@@ -38,4 +38,7 @@ private:
 
     static QJsonObject shortcutsToJson(const Shortcuts& sc);
     static Shortcuts   jsonToShortcuts(const QJsonObject& obj);
+
+    static QString replaceEnvVars(const QString& path);
+    static QString expandEnvVars(const QString& path);
 };


### PR DESCRIPTION
## Summary
- Add helpers for substituting environment variables in setting paths
- Persist, export and import paths using placeholders so different users can share configuration

## Testing
- ❌ `qmake` *(command not found)*
- ⚠️ `apt-get update` *(403 errors: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acc3c28178832886b655be994d9fd4