### PR TITLE
ci: install NSIS UAC plugin for installer

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -140,12 +140,23 @@ jobs:
           name: digitizer2-windows-portable
           path: dist/**
 
-      # 🔹 NSIS installer build
-      - name: Install NSIS
-        run: choco install nsis -y
+    # 🔹 NSIS installer build
+    - name: Install NSIS
+      run: choco install nsis -y
 
-      - name: Build installer (NSIS)
-        run: makensis installer.nsi
+    - name: Install UAC plugin
+      shell: pwsh
+      run: |
+        $nsisHome = "${env:ProgramFiles(x86)}\NSIS"
+        echo "NSIS_HOME=$nsisHome" >> $env:GITHUB_ENV
+        $zip = "$env:RUNNER_TEMP\nsis-uac.zip"
+        Invoke-WebRequest "https://github.com/DavidRogers/nsis-uac/releases/latest/download/UAC.zip" -OutFile $zip
+        Expand-Archive $zip -DestinationPath "$env:RUNNER_TEMP\nsis-uac"
+        Copy-Item "$env:RUNNER_TEMP\nsis-uac\Plugins\UAC.dll" "$nsisHome\Plugins" -Force
+        Copy-Item "$env:RUNNER_TEMP\nsis-uac\Include\UAC.nsh" "$nsisHome\Include" -Force
+
+    - name: Build installer (NSIS)
+      run: makensis installer.nsi
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/installer.nsi
+++ b/installer.nsi
@@ -2,7 +2,7 @@
 !include "FileFunc.nsh"
 !include "LogicLib.nsh"
 !include "nsDialogs.nsh"
-;!include "UAC.nsh"
+!include "UAC.nsh"
 
 ; ==== ZÁKLADNÍ INFO (uprav podle sebe) ====
 !define APP_NAME     "Digitizer2"


### PR DESCRIPTION
## Summary
- install nsis-uac plugin before building installer
- enable UAC include in installer script

## Testing
- `sudo apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: 403 Forbidden)*
- `makensis installer.nsi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ad0f0c0832892da6cfce3642298