### PR TITLE
fix: indent NSIS steps in Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -140,23 +140,23 @@ jobs:
           name: digitizer2-windows-portable
           path: dist/**
 
-    # 🔹 NSIS installer build
-    - name: Install NSIS
-      run: choco install nsis -y
+      # 🔹 NSIS installer build
+      - name: Install NSIS
+        run: choco install nsis -y
 
-    - name: Install UAC plugin
-      shell: pwsh
-      run: |
-        $nsisHome = "${env:ProgramFiles(x86)}\NSIS"
-        echo "NSIS_HOME=$nsisHome" >> $env:GITHUB_ENV
-        $zip = "$env:RUNNER_TEMP\nsis-uac.zip"
-        Invoke-WebRequest "https://github.com/DavidRogers/nsis-uac/releases/latest/download/UAC.zip" -OutFile $zip
-        Expand-Archive $zip -DestinationPath "$env:RUNNER_TEMP\nsis-uac"
-        Copy-Item "$env:RUNNER_TEMP\nsis-uac\Plugins\UAC.dll" "$nsisHome\Plugins" -Force
-        Copy-Item "$env:RUNNER_TEMP\nsis-uac\Include\UAC.nsh" "$nsisHome\Include" -Force
+      - name: Install UAC plugin
+        shell: pwsh
+        run: |
+          $nsisHome = "${env:ProgramFiles(x86)}\NSIS"
+          echo "NSIS_HOME=$nsisHome" >> $env:GITHUB_ENV
+          $zip = "$env:RUNNER_TEMP\nsis-uac.zip"
+          Invoke-WebRequest "https://github.com/DavidRogers/nsis-uac/releases/latest/download/UAC.zip" -OutFile $zip
+          Expand-Archive $zip -DestinationPath "$env:RUNNER_TEMP\nsis-uac"
+          Copy-Item "$env:RUNNER_TEMP\nsis-uac\Plugins\UAC.dll" "$nsisHome\Plugins" -Force
+          Copy-Item "$env:RUNNER_TEMP\nsis-uac\Include\UAC.nsh" "$nsisHome\Include" -Force
 
-    - name: Build installer (NSIS)
-      run: makensis installer.nsi
+      - name: Build installer (NSIS)
+        run: makensis installer.nsi
 
       - name: Upload installer
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- keep NSIS build comment and steps within `steps` list for Windows workflow

## Testing
- `pip install --user yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `act -n -j build` *(fails: command not found)*
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/windows-build.yml"); puts "YAML parsed successfully"'`

------
https://chatgpt.com/codex/tasks/task_e_68ad5d6897cc8328805f7a364aae868f