### PR TITLE
fix: update nsis-uac plugin URL

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -150,7 +150,7 @@ jobs:
           $nsisHome = "${env:ProgramFiles(x86)}\NSIS"
           echo "NSIS_HOME=$nsisHome" >> $env:GITHUB_ENV
           $zip = "$env:RUNNER_TEMP\nsis-uac.zip"
-          Invoke-WebRequest "https://github.com/DavidRogers/nsis-uac/releases/latest/download/UAC.zip" -OutFile $zip
+          Invoke-WebRequest -Uri "https://github.com/DavidRogers/nsis-uac/releases/download/v2.1/UAC.zip" -OutFile $zip
           Expand-Archive $zip -DestinationPath "$env:RUNNER_TEMP\nsis-uac"
           Copy-Item "$env:RUNNER_TEMP\nsis-uac\Plugins\UAC.dll" "$nsisHome\Plugins" -Force
           Copy-Item "$env:RUNNER_TEMP\nsis-uac\Include\UAC.nsh" "$nsisHome\Include" -Force


### PR DESCRIPTION
## Summary
- fix GitHub Actions Windows build by updating nsis-uac plugin URL to a valid release asset

## Testing
- `act -n -j build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6119f84c83289ec4609ba14750c6