### PR TITLE
Add serial debug and handle CR line endings

### DIFF
--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -31,7 +31,7 @@ double AppManager::getBeta()
 void AppManager::setAngles(double alfa, double beta, int index)
 {
     endPointBefore_ = endPointArm2_;
-    qDebug() << "appmanager alfa" << alfa_ << "beta" << beta_ << "index" << index;
+    qDebug() << "AppManager::setAngles input" << alfa << beta << index;
     alfa_ = alfa;
     beta_ = beta;
 
@@ -54,7 +54,7 @@ void AppManager::setAngles(double alfa, double beta, int index)
 
     if (endPointBefore_ != endPointArm2_) {
         emit armsUpdated(Arm1Angle_, Arm2Angle_, endPointArm1_, endPointArm2_);
-        qDebug() << "appmanager alfa" << alfa_ << "beta" << beta_ << "index" << index;
+        qDebug() << "AppManager::setAngles armsUpdated" << alfa_ << beta_ << index;
     }
 
     indexBefore_ = index;
@@ -277,11 +277,13 @@ void AppManager::send(const QByteArray& data)
 
 void AppManager::onSerialData(const Frame& frame)
 {
+    qDebug() << "AppManager::onSerialData" << frame.data;
     emit serialData(frame.data);
 }
 
 void AppManager::onSerialLine(const QByteArray& line)
 {
+    qDebug() << "AppManager::onSerialLine" << line;
     if (line.startsWith("#A:")) {
         alfa_ = line.mid(3).trimmed().toDouble();
         alfaReceived_ = true;

--- a/serialmanager.cpp
+++ b/serialmanager.cpp
@@ -4,6 +4,7 @@
 #include "simworker.h"
 #include "modbusworker.h"
 #include <QTextStream>
+#include <QDebug>
 
 SerialManager::SerialManager(QObject* parent) : QObject(parent) {
     // Vlákno držíme persistentně; workera do něj vždy přesuneme.
@@ -104,6 +105,8 @@ void SerialManager::onWorkerClosed()  { emit closed(); }
 void SerialManager::onWorkerError(const QString& msg) { emit errorOccured(msg); }
 
 void SerialManager::onWorkerFrame(const Frame& f) {
+    qDebug() << "SerialManager::onWorkerFrame" << f.data;
+
     // pokud je zapnuté nahrávání, ulož řádek "ts;payload\n"
     if (recording_ && recordFile_.isOpen()) {
         QTextStream out(&recordFile_);

--- a/serialworker.cpp
+++ b/serialworker.cpp
@@ -43,12 +43,19 @@ void SerialWorker::onReadyRead() {
     // Čteme po částech, seskládáme na řádky (A/B/I chodí „po řádcích“)
     //qDebug() << "prisly data";
     lineBuffer_.append(port_.readAll());
+    qDebug() << "SerialWorker::onReadyRead buffer" << lineBuffer_;
+
+    // sjednoť ukončení řádků: nahraď CR za LF
+    lineBuffer_.replace('\r', '\n');
+
     int idx;
     while ((idx = lineBuffer_.indexOf('\n')) >= 0) {
         QByteArray line = lineBuffer_.left(idx);
-        // odstraníme i \r případně
-        if (!line.isEmpty() && line.endsWith('\r')) line.chop(1);
-        lineBuffer_.remove(0, idx+1);
+        lineBuffer_.remove(0, idx + 1);
+        if (line.isEmpty())
+            continue;
+
+        qDebug() << "SerialWorker frame" << line;
 
         Frame f;
         f.data = line;


### PR DESCRIPTION
## Summary
- Add comprehensive debug logs to serial data flow and AppManager
- Handle carriage return line endings in SerialWorker
- Log frames in SerialManager for easier tracing

## Testing
- `qmake digitizer2.pro` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*


------
https://chatgpt.com/codex/tasks/task_e_68aeeca00b9483288aa816b2c834dc34