### PR TITLE
Ensure SimWorker timer runs in its thread

### DIFF
--- a/simworker.cpp
+++ b/simworker.cpp
@@ -2,63 +2,86 @@
 #include "simworker.h"
 #include <QDateTime>
 #include <QStringList>
+#include <QThread>
 
-SimWorker::SimWorker(const SimulationParams& params, QObject* parent)
-    : IDataSourceWorker(parent), params_(params)
-{
-    connect(&timer_, &QTimer::timeout, this, &SimWorker::tick);
-}
+SimWorker::SimWorker(const SimulationParams &params, QObject *parent)
+    : IDataSourceWorker(parent), params_(params) {}
 
 void SimWorker::open() {
-    if (file_.isOpen()) file_.close();
-    file_.setFileName(params_.logFile);
-    if (!file_.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        emit errorOccured(QStringLiteral("Nelze otevřít log %1").arg(params_.logFile));
-        return;
-    }
-    startWallMsec_ = QDateTime::currentMSecsSinceEpoch();
-    firstTs_ = -1;
-    timer_.start(1); // rychlý tick – dávkujeme sami dle časů v souboru
-    emit opened();
+  if (QThread::currentThread() != thread()) {
+    QMetaObject::invokeMethod(this, &SimWorker::open, Qt::QueuedConnection);
+    return;
+  }
+
+  if (file_.isOpen())
+    file_.close();
+  file_.setFileName(params_.logFile);
+  if (!file_.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    emit errorOccured(
+        QStringLiteral("Nelze otevřít log %1").arg(params_.logFile));
+    return;
+  }
+  startWallMsec_ = QDateTime::currentMSecsSinceEpoch();
+  firstTs_ = -1;
+  if (!timer_) {
+    timer_ = new QTimer(this);
+    timer_->moveToThread(thread());
+    connect(timer_, &QTimer::timeout, this, &SimWorker::tick);
+  }
+  timer_->start(1); // rychlý tick – dávkujeme sami dle časů v souboru
+  emit opened();
 }
 
 void SimWorker::close() {
-    timer_.stop();
-    if (file_.isOpen()) file_.close();
-    emit closed();
+  if (QThread::currentThread() != thread()) {
+    QMetaObject::invokeMethod(this, &SimWorker::close, Qt::QueuedConnection);
+    return;
+  }
+
+  if (timer_)
+    timer_->stop();
+  if (file_.isOpen())
+    file_.close();
+  emit closed();
 }
 
 void SimWorker::tick() {
-    // čteme řádky a vydáváme je podle časové značky (ts_msec)
-    while (file_.canReadLine()) {
-        const QByteArray raw = file_.readLine();
-        const QString s = QString::fromUtf8(raw).trimmed();
-        if (s.isEmpty()) continue;
+  // čteme řádky a vydáváme je podle časové značky (ts_msec)
+  while (file_.canReadLine()) {
+    const QByteArray raw = file_.readLine();
+    const QString s = QString::fromUtf8(raw).trimmed();
+    if (s.isEmpty())
+      continue;
 
-        const QStringList parts = s.split(';');
-        if (parts.size() < 2) continue; // špatný řádek
+    const QStringList parts = s.split(';');
+    if (parts.size() < 2)
+      continue; // špatný řádek
 
-        bool ok=false;
-        qint64 ts = parts[0].toLongLong(&ok);
-        if (!ok) continue;
-        const QByteArray payload = parts.mid(1).join(";").toUtf8();
+    bool ok = false;
+    qint64 ts = parts[0].toLongLong(&ok);
+    if (!ok)
+      continue;
+    const QByteArray payload = parts.mid(1).join(";").toUtf8();
 
-        if (firstTs_ < 0) firstTs_ = ts;
+    if (firstTs_ < 0)
+      firstTs_ = ts;
 
-        // spočítat kdy má být tento řádek vydán vzhledem k prvnímu a k speedFactor
-        const qint64 rel = ts - firstTs_;
-        const qint64 targetDelay = qint64(double(rel) / qMax(0.0001, params_.speedFactor));
-        const qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - startWallMsec_;
-        if (elapsed < targetDelay) {
-            // ještě brzy – necháme timer doběhnout později
-            return;
-        }
-
-        Frame f{ payload, QDateTime::currentMSecsSinceEpoch() };
-        emit frameReceived(f);
-        // pokračujeme na další řádek (možné dohnání při zrychlení)
-        qDebug() << "tick ";
+    // spočítat kdy má být tento řádek vydán vzhledem k prvnímu a k speedFactor
+    const qint64 rel = ts - firstTs_;
+    const qint64 targetDelay =
+        qint64(double(rel) / qMax(0.0001, params_.speedFactor));
+    const qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - startWallMsec_;
+    if (elapsed < targetDelay) {
+      // ještě brzy – necháme timer doběhnout později
+      return;
     }
-    // Konec souboru
-    timer_.stop();
+
+    Frame f{payload, QDateTime::currentMSecsSinceEpoch()};
+    emit frameReceived(f);
+    // pokračujeme na další řádek (možné dohnání při zrychlení)
+    qDebug() << "tick ";
+  }
+  // Konec souboru
+  if (timer_)
+    timer_->stop();
 }

--- a/simworker.h
+++ b/simworker.h
@@ -1,30 +1,30 @@
 // simworker.h
 #pragma once
 #include "idatasourceworker.h"
+#include <QDebug>
 #include <QFile>
 #include <QTimer>
-#include <QDebug>
 
 // Jednoduchý přehrávač z CSV/NDJSON, kde je sloupec ts a data.
 // Pro jednoduchost použijeme CSV: ts_msec;payload
 class SimWorker : public IDataSourceWorker {
-    Q_OBJECT
+  Q_OBJECT
 public:
-    explicit SimWorker(const SimulationParams& params, QObject* parent=nullptr);
+  explicit SimWorker(const SimulationParams &params, QObject *parent = nullptr);
 
 public slots:
-    void open() override;
-    void close() override;
-    void send(const QByteArray&) override {} // simulace neodesílá
+  void open() override;
+  void close() override;
+  void send(const QByteArray &) override {} // simulace neodesílá
 
 private slots:
-    void tick();
+  void tick();
 
 private:
-    SimulationParams params_;
-    QFile file_;
-    qint64 startWallMsec_ = 0;
-    qint64 firstTs_ = -1;
-    QTimer timer_;
-    QString pendingLine_;
+  SimulationParams params_;
+  QFile file_;
+  qint64 startWallMsec_ = 0;
+  qint64 firstTs_ = -1;
+  QTimer *timer_ = nullptr;
+  QString pendingLine_;
 };


### PR DESCRIPTION
## Summary
- Re-route SimWorker's open/close to its own thread when called externally
- Move the timer to the worker thread and guard cross-thread start/stop

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af06c51cac8328876882bf9efc04f3