### PR TITLE
Refactor scene setup to use SettingsManager

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -43,7 +43,6 @@ public:
     ~MainWindow();
     AppManager* appManager() const { return appManager_; }
     SettingsManager* settingsManager() const { return settingsManager_; }
-    Settings currentSettings_;
     void onAddPointModeChanged(AddPointMode mode);
     void updateUiForMode(AddPointMode mode);
     MeasureDialog* measure = nullptr;


### PR DESCRIPTION
## Summary
- Drop redundant `currentSettings_` member from MainWindow
- Read settings directly from SettingsManager when preparing the scene and handling actions
- Adjust saving and loading helpers to update settings via SettingsManager

## Testing
- `qmake` *(command not found)*
- `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af488aec2c8328af4da09c6b04ab8d