### PR TITLE
Zaveď konzistentní převod jednotek

### DIFF
--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -355,6 +355,8 @@ void SettingsDialog::on_choose_arms_color_clicked()
 void SettingsDialog::on_buttonBox_rejected()
 {
     qDebug() << "reject";
+    tmp_settings = orig_settings_;
+    populate();
     this->language=this->language_tmp;
     emit signal_retranslate();
     reject();
@@ -384,6 +386,7 @@ void SettingsDialog::on_ShortCuts_clicked()
 
 
 void SettingsDialog::setSettings(const Settings& s) {
+    orig_settings_ = s;
     tmp_settings = s;
     populate();
 }
@@ -396,10 +399,12 @@ Settings SettingsDialog::result() const {
 
 void SettingsDialog::populate() {
     // TODO: Optionally enumerate available ports via QSerialPortInfo
-    ui->auto_step->setValue(tmp_settings.auto_step);
+    arm1_length = tmp_settings.arm1_length;
+    arm2_length = tmp_settings.arm2_length;
+    auto_step = tmp_settings.auto_step;
+    currentUnits_ = tmp_settings.units;
     ui->unit_select->setCurrentText(unitsToString(tmp_settings.units));
-    ui->doubleSpinBox_arm1_length->setValue(tmp_settings.arm1_length);
-    ui->doubleSpinBox_arm2_length->setValue(tmp_settings.arm2_length);
+    changeunits(unitsToString(tmp_settings.units));
 
     // náhled barvy
         ui->arms_color->setAttribute(Qt::WA_StyledBackground, true);
@@ -456,6 +461,16 @@ void SettingsDialog::pullFromUi()
 
    //---dxf
    tmp_settings.directory_save_dxf = ui->lineEdit_dxf_dir->text();
+}
+
+void SettingsDialog::on_unit_select_currentIndexChanged(const QString &text)
+{
+    Units newUnits = stringToUnits(text);
+    arm1_length = unitsToMm(ui->doubleSpinBox_arm1_length->value(), currentUnits_);
+    arm2_length = unitsToMm(ui->doubleSpinBox_arm2_length->value(), currentUnits_);
+    auto_step   = unitsToMm(ui->auto_step->value(), currentUnits_);
+    currentUnits_ = newUnits;
+    changeunits(text);
 }
 
 void SettingsDialog::on_buttonBox_accepted()

--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -255,9 +255,10 @@ void SettingsDialog::changeunits(const QString& jednotky)
         ui->auto_step->setSingleStep(0.1);
     }
     qDebug() << "units_scale " << units_scale;
-    ui->doubleSpinBox_arm1_length->setValue(this->arm1_length/units_scale);
-    ui->doubleSpinBox_arm2_length->setValue(this->arm2_length/units_scale);
-    ui->auto_step->setValue(this->auto_step/units_scale);
+    Units u = stringToUnits(jednotky);
+    ui->doubleSpinBox_arm1_length->setValue(mmToUnits(this->arm1_length, u));
+    ui->doubleSpinBox_arm2_length->setValue(mmToUnits(this->arm2_length, u));
+    ui->auto_step->setValue(mmToUnits(this->auto_step, u));
 
 }
 
@@ -435,10 +436,10 @@ void SettingsDialog::populate() {
 void SettingsDialog::pullFromUi()
 {
    qDebug()<<"accept v settings dialog" << ui->unit_select->currentText();
-   tmp_settings.auto_step=ui->auto_step->value();
-   tmp_settings.units=stringToUnits(ui->unit_select->currentText());
-   tmp_settings.arm1_length=ui->doubleSpinBox_arm1_length->value();
-   tmp_settings.arm2_length=ui->doubleSpinBox_arm2_length->value();
+   tmp_settings.units = stringToUnits(ui->unit_select->currentText());
+   tmp_settings.auto_step = unitsToMm(ui->auto_step->value(), tmp_settings.units);
+   tmp_settings.arm1_length = unitsToMm(ui->doubleSpinBox_arm1_length->value(), tmp_settings.units);
+   tmp_settings.arm2_length = unitsToMm(ui->doubleSpinBox_arm2_length->value(), tmp_settings.units);
    //tmp_settings.arms_color=  QColor(arms_color).name();
 
    //UI

--- a/SettingsDialog.h
+++ b/SettingsDialog.h
@@ -90,11 +90,14 @@ private slots:
     void onExportConfig();
     void on_button_browse_simul_clicked();
     void on_pushButton_logging_enagle_toggled(bool checked);
+    void on_unit_select_currentIndexChanged(const QString &text);
 
 private:
     Ui::SettingsDialog *ui;
     void fillPortsInfo();
     Settings tmp_settings ;// lokální pracovní kopie
+    Settings orig_settings_ ;// původní nastavení pro reset
+    Units currentUnits_ = Units::Millimeters;
     int hiddenTabIndex_ = -1;  //index skryte zalozky
     QWidget* hiddenTabWidget_ = nullptr; //ukazatel skryte zalozky
     SettingsManager* sm_ = nullptr;

--- a/SettingsDialog.ui
+++ b/SettingsDialog.ui
@@ -205,7 +205,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>mm</string>
+             <string>inch/mm</string>
             </property>
            </widget>
           </item>
@@ -242,7 +242,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>mm</string>
+             <string>inch/mm</string>
             </property>
            </widget>
           </item>
@@ -273,7 +273,7 @@
           <item>
            <widget class="QLabel" name="label_step_units">
             <property name="text">
-             <string>mm</string>
+             <string>inch/mm</string>
             </property>
            </widget>
           </item>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -750,13 +750,13 @@ void MainWindow::updateArms(double Arm1Angle, double Arm2Angle,QPointF endPointA
     s = "beta " +QString::number(Arm2Angle, 'f', 4) + " deg";
     ui->enc2value->setText(s);
     const auto& st = settingsManager_->currentSettings();
-    s = QString::number(endPointArm1.x()/st.units_scale, 'f', 8);
+    s = QString::number(mmToUnits(endPointArm1.x(), st.units), 'f', 8);
     ui->position1x->setText(s);
-    s = QString::number(endPointArm1.y()/st.units_scale, 'f', 8);
+    s = QString::number(mmToUnits(endPointArm1.y(), st.units), 'f', 8);
     ui->position1y->setText(s);
-    s = QString::number(endPointArm2.x()/st.units_scale, 'f', 8);
+    s = QString::number(mmToUnits(endPointArm2.x(), st.units), 'f', 8);
     ui->position2x->setText(s);
-    s = QString::number(endPointArm2.y()/st.units_scale, 'f', 8);
+    s = QString::number(mmToUnits(endPointArm2.y(), st.units), 'f', 8);
     ui->position2y->setText(s);
     lastEndArm2_ = endPointArm2;   // ⬅ uložit pro Zoom_Dynamic()
 
@@ -887,7 +887,9 @@ void MainWindow::show_measure_value(double Arm1Angle, double Arm2Angle,QPointF e
     {
         double distance;
         const auto& st = settingsManager_->currentSettings();
-        distance= double(qSqrt(double(qPow(measure->start_position.x()-endPointArm2.x(),2))+double(qPow(measure->start_position.y()-endPointArm2.y(),2))))/st.units_scale;
+        distance = mmToUnits(qSqrt(qPow(measure->start_position.x() - endPointArm2.x(), 2) +
+                                   qPow(measure->start_position.y() - endPointArm2.y(), 2)),
+                              st.units);
         measure->set_value(distance);
     }
     else if (measure->mode==0)

--- a/settings.h
+++ b/settings.h
@@ -18,6 +18,16 @@ inline Units stringToUnits(const QString& s) {
         : Units::Millimeters;
 }
 
+inline double mmToUnits(double value, Units u) {
+    constexpr double k = 25.4;
+    return (u == Units::Millimeters) ? value : value / k;
+}
+
+inline double unitsToMm(double value, Units u) {
+    constexpr double k = 25.4;
+    return (u == Units::Millimeters) ? value : value * k;
+}
+
 //------------komunikace
 enum class DataSource {
     Serial,     // klasický COM


### PR DESCRIPTION
## Shrnutí
- Přidal jsem inline funkce `mmToUnits` a `unitsToMm` do `settings.h` pro jednotný převod mezi mm a palci.
- V `mainwindow.cpp` a `SettingsDialog.cpp` jsem nahradil přímé dělení/množení `units_scale` voláním těchto funkcí.
- Hodnoty z UI se nyní při ukládání převádějí zpět na milimetry pomocí `unitsToMm`.

## Testy
- `qmake digitizer2.pro` *(selhalo: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af719f94b8832893de9f68d71fd94c