### PR TITLE
Handle DXF export units and scaling

### DIFF
--- a/GraphicsItems.cpp
+++ b/GraphicsItems.cpp
@@ -28,10 +28,11 @@ void GraphicsItems::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
     Q_UNUSED(widget);
 }
 
-void GraphicsItems::export_dxf(DL_Dxf& dxf, DL_WriterA& dw)
+void GraphicsItems::export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale)
 {
     Q_UNUSED(dxf);
     Q_UNUSED(dw);
+    Q_UNUSED(scale);
     qDebug() << "export mygraphicsitem" << this->pen;
 }
 
@@ -82,12 +83,12 @@ void mypoint::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
     painter->drawPoint(1,1);
 }
 
-void mypoint::export_dxf(DL_Dxf& dxf, DL_WriterA& dw)
+void mypoint::export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale)
 {
     qDebug() << "export mypoint" << this->pos();
     dxf.writeComment(dw, QString("alfa: %1").arg(-alfa).toStdString());
     dxf.writeComment(dw, QString("beta: %1").arg(-beta).toStdString());
-    DL_PointData data(this->pos().x(), this->pos().y() * (-1), 0.0);
+    DL_PointData data(this->pos().x() * scale, this->pos().y() * (-scale), 0.0);
     dxf.writePoint(dw, data, DL_Attributes("0", 256, -1, "BYLAYER", 1.0));
 }
 
@@ -186,16 +187,16 @@ void mypolyline::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
 
 }
 
-void mypolyline::export_dxf(DL_Dxf& dxf, DL_WriterA& dw)
+void mypolyline::export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale)
 {
     qDebug() << "export mypolyline" << this->pen;
     for (int i = 0; i < mypolygon->count() - 1; i++) {
         DL_LineData lineData(
-            mypolygon->at(i).x() + pos().x(),
-            (mypolygon->at(i).y() + pos().y()) * (-1),
+            (mypolygon->at(i).x() + pos().x()) * scale,
+            (mypolygon->at(i).y() + pos().y()) * (-scale),
             0.0,
-            mypolygon->at(i + 1).x() + pos().x(),
-            (mypolygon->at(i + 1).y() + pos().y()) * (-1),
+            (mypolygon->at(i + 1).x() + pos().x()) * scale,
+            (mypolygon->at(i + 1).y() + pos().y()) * (-scale),
             0.0);
         dxf.writeLine(dw, lineData, DL_Attributes("0", 256, -1, "BYLAYER", 1.0));
     }
@@ -310,12 +311,12 @@ QRectF mycircle::boundingRect() const
 
 }
 
-void mycircle::export_dxf(DL_Dxf& dxf, DL_WriterA& dw)
+void mycircle::export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale)
 {
     qDebug() << "export mycircle" << this->pen;
-    DL_CircleData circleData(center.x(), center.y() * (-1), 0.0, radius);
+    DL_CircleData circleData(center.x() * scale, center.y() * (-scale), 0.0, radius * scale);
     dxf.writeCircle(dw, circleData, DL_Attributes("0", 256, -1, "BYLAYER", 1.0));
-    DL_PointData pointData(center.x(), center.y() * (-1), 0.0);
+    DL_PointData pointData(center.x() * scale, center.y() * (-scale), 0.0);
     dxf.writePoint(dw, pointData, DL_Attributes("0", 256, -1, "BYLAYER", 1.0));
 }
 

--- a/GraphicsItems.h
+++ b/GraphicsItems.h
@@ -30,7 +30,7 @@ public:
     bool finished;
     QRectF m_boundingRect;
 
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw);  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale);  //export to dxf file
     virtual void save(QTextStream &out) = 0;  // čistě virtuální metoda v základní třídě
 
 
@@ -56,7 +56,7 @@ public:
     void addPointToShape(const QPointF&) override ;
     QRectF boundingRect()const override;
     void paint(QPainter *painter,const QStyleOptionGraphicsItem *option, QWidget *widget) override ;
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw) override;  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale) override;  //export to dxf file
     void save(QTextStream &out) override;
 
     QString typeName() const override { return "point"; }
@@ -79,7 +79,7 @@ public:
     QRectF boundingRect()const override;
     void addPointToShape(const QPointF&) override ;
     void paint(QPainter *painter,const QStyleOptionGraphicsItem *option, QWidget *widget) override ;
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw) override;  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale) override;  //export to dxf file
     void save(QTextStream &out) override;
 
 
@@ -112,7 +112,7 @@ public:
     void addPointToShape(const QPointF&) override ;
     QRectF boundingRect()const override;
     void paint(QPainter *painter,const QStyleOptionGraphicsItem *option, QWidget *widget) override ;
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw) override;  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, double scale) override;  //export to dxf file
     void save(QTextStream &out) override;
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -478,6 +478,7 @@ void MainWindow::on_actionSave_dxf_triggered()
     QDateTime date = QDateTime::currentDateTime();
     QString formattedTime = date.toString("yyyy-MM-dd-hh-mm-ss");
     auto settings = settingsManager_->currentSettings();
+    double scale = 1.0 / settings.units_scale;
     QString export_file = QFileDialog::getSaveFileName(this, tr("Export DXF"), settings.directory_save_dxf + "/" + formattedTime, "DXF files (*.dxf)");
     if (export_file.isEmpty()) {
         return;
@@ -495,6 +496,9 @@ void MainWindow::on_actionSave_dxf_triggered()
     }
 
     dxf.writeHeader(*dw);
+    int insUnits = (settings.units_scale == 1.0) ? 4 : 1;
+    dw->dxfString(9, "$INSUNITS");
+    dw->dxfInt(70, insUnits);
     dw->sectionEnd();
     dw->sectionEntities();
 
@@ -504,7 +508,7 @@ void MainWindow::on_actionSave_dxf_triggered()
 
     for (QGraphicsItem* item : scene->items()) {
         if (auto fm = dynamic_cast<GraphicsItems*>(item)) {
-            fm->export_dxf(dxf, *dw);
+            fm->export_dxf(dxf, *dw, scale);
         }
     }
 


### PR DESCRIPTION
## Summary
- Compute scale from settings and pass it to item DXF exporters
- Apply scale to coordinates when exporting points, polylines, and circles
- Write $INSUNITS to DXF header based on selected units

## Testing
- `qmake -v` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `g++ -std=c++17 -I3rdparty/dxflib/src -c mainwindow.cpp GraphicsItems.cpp` *(fails: Qt headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af7508a6ec8328a0ded49096cfb468