### PR TITLE
Show units in MeasureDialog

### DIFF
--- a/MeasureDialog.cpp
+++ b/MeasureDialog.cpp
@@ -90,16 +90,18 @@ void MeasureDialog::set_value(double value)
 {
     // get units from settings
     int decimals = 2; // default
+    QString unitText = QStringLiteral("mm");
     if (settingsManager_) {
         const auto& s = settingsManager_->currentSettings();
-        // Assume Units::Millimeters => mm, Units::Inches => inches
         if (s.units == Units::Millimeters) {
             decimals = 1;
         } else {
             decimals = 2;
         }
+        unitText = unitsToString(s.units);
     }
     ui->lcdNumber->display(QString::number(value, 'f', decimals));
+    ui->unitLabel->setText(unitText);
 }
 
 void MeasureDialog::set_color(QColor color)

--- a/MeasureDialog.ui
+++ b/MeasureDialog.ui
@@ -28,7 +28,10 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+     <property name="spacing">
+      <number>4</number>
+     </property>
+     <item alignment="Qt::AlignBottom">
       <widget class="QLCDNumber" name="lcdNumber">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -50,16 +53,24 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="unitLabel">
+     <item alignment="Qt::AlignBottom">
+     <widget class="QLabel" name="unitLabel">
+       <property name="font">
+        <font>
+         <pointsize>20</pointsize>
+        </font>
+       </property>
        <property name="text">
         <string>mm</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignLeft</set>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-  </layout>
+    </item>
+   </layout>
  </widget>
  <resources/>
  <connections/>

--- a/MeasureDialog.ui
+++ b/MeasureDialog.ui
@@ -27,26 +27,37 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLCDNumber" name="lcdNumber">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>20</pointsize>
-       <kerning>false</kerning>
-      </font>
-     </property>
-     <property name="digitCount">
-      <number>7</number>
-     </property>
-     <property name="value" stdset="0">
-      <double>12336.250000000000000</double>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLCDNumber" name="lcdNumber">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>20</pointsize>
+         <kerning>false</kerning>
+        </font>
+       </property>
+       <property name="digitCount">
+        <number>7</number>
+       </property>
+       <property name="value" stdset="0">
+        <double>12336.250000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="unitLabel">
+       <property name="text">
+        <string>mm</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Summary
- add unit label next to measurement display
- show chosen units from SettingsManager in MeasureDialog

## Testing
- `apt-get update` *(fails: The repository is not signed)*
- `qmake digitizer2.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af759a2f4c8328b8bbd40aaa3b3999