### PR TITLE
Export DXF respektuje nastavené jednotky

### DIFF
--- a/GraphicsItems.h
+++ b/GraphicsItems.h
@@ -4,6 +4,7 @@
 #include <QPainter>
 #include <QList>
 #include <QtGlobal>
+#include "settings.h"
 
 class QTextStream;
 class DL_Dxf;
@@ -30,7 +31,7 @@ public:
     bool finished;
     QRectF m_boundingRect;
 
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw);  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, Units units);  //export to dxf file
     virtual void save(QTextStream &out) = 0;  // čistě virtuální metoda v základní třídě
 
 
@@ -56,7 +57,7 @@ public:
     void addPointToShape(const QPointF&) override ;
     QRectF boundingRect()const override;
     void paint(QPainter *painter,const QStyleOptionGraphicsItem *option, QWidget *widget) override ;
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw) override;  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, Units units) override;  //export to dxf file
     void save(QTextStream &out) override;
 
     QString typeName() const override { return "point"; }
@@ -79,7 +80,7 @@ public:
     QRectF boundingRect()const override;
     void addPointToShape(const QPointF&) override ;
     void paint(QPainter *painter,const QStyleOptionGraphicsItem *option, QWidget *widget) override ;
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw) override;  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, Units units) override;  //export to dxf file
     void save(QTextStream &out) override;
 
 
@@ -112,7 +113,7 @@ public:
     void addPointToShape(const QPointF&) override ;
     QRectF boundingRect()const override;
     void paint(QPainter *painter,const QStyleOptionGraphicsItem *option, QWidget *widget) override ;
-    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw) override;  //export to dxf file
+    virtual void export_dxf(DL_Dxf& dxf, DL_WriterA& dw, Units units) override;  //export to dxf file
     void save(QTextStream &out) override;
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -15,6 +15,7 @@
 #include "SettingsDialog.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include "settings.h"
 
 MainWindow::MainWindow(AppManager* app, QWidget* parent)
     : QMainWindow(parent)
@@ -495,16 +496,24 @@ void MainWindow::on_actionSave_dxf_triggered()
     }
 
     dxf.writeHeader(*dw);
+    dw->dxfString(9, "$INSUNITS");
+    dw->dxfInt(70, settings.units == Units::Millimeters ? 4 : 1);
     dw->sectionEnd();
     dw->sectionEntities();
 
-    dxf.writeComment(*dw, QString("ARM1: %1").arg(settings.arm1_length).toStdString());
-    dxf.writeComment(*dw, QString("ARM2: %1").arg(settings.arm2_length).toStdString());
+    dxf.writeComment(*dw, QString("ARM1: %1 %2")
+                               .arg(mmToUnits(settings.arm1_length, settings.units))
+                               .arg(unitsToString(settings.units))
+                               .toStdString());
+    dxf.writeComment(*dw, QString("ARM2: %1 %2")
+                               .arg(mmToUnits(settings.arm2_length, settings.units))
+                               .arg(unitsToString(settings.units))
+                               .toStdString());
     dxf.writePoint(*dw, DL_PointData(0.0, 0.0, 0.0), DL_Attributes("0", 256, -1, "BYLAYER", 1.0));
 
     for (QGraphicsItem* item : scene->items()) {
         if (auto fm = dynamic_cast<GraphicsItems*>(item)) {
-            fm->export_dxf(dxf, *dw);
+            fm->export_dxf(dxf, *dw, settings.units);
         }
     }
 


### PR DESCRIPTION
## Summary
- převod souřadnic a poloměrů do vybraných jednotek před exportem DXF
- zápis jednotek do hlavičky DXF a komentářů s délkami ramen
- rozšíření rozhraní `export_dxf` pro předání aktuálních jednotek

## Testing
- `qmake` *(command not found)*
- `make` *(no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68aff126b6988328a1faf2eb97964604