### PR TITLE
Enable live language switching in settings dialog

### DIFF
--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -55,6 +55,8 @@ SettingsDialog::SettingsDialog(QWidget *parent, SettingsManager* sm, SerialManag
 
     populate();
 
+    connect(this, &SettingsDialog::languageChanged, this, &SettingsDialog::retranslate);
+
     fillPortsInfo();
 }
 
@@ -225,7 +227,7 @@ void SettingsDialog::retranslate()
 {
     qDebug() <<"SettingsDialog::retranslate() " ;
     ui->retranslateUi(this);
-    ui->ComboBox_language->setCurrentText(language);
+    ui->ComboBox_language->setCurrentText(tmp_settings.language);
 
     fillPortsInfo();
 
@@ -357,8 +359,7 @@ void SettingsDialog::on_buttonBox_rejected()
     qDebug() << "reject";
     tmp_settings = orig_settings_;
     populate();
-    this->language=this->language_tmp;
-    emit signal_retranslate();
+    emit languageChanged(tmp_settings.language);
     reject();
 
 }
@@ -367,9 +368,8 @@ void SettingsDialog::on_buttonBox_rejected()
 void SettingsDialog::on_ComboBox_language_activated(const QString &arg1)
 {
     qDebug() << "on_ComboBox_language_activated " << arg1 ;
-    this->language_tmp=this->language;
-    this->language=arg1;
-    emit signal_retranslate();
+    tmp_settings.language = arg1;
+    emit languageChanged(arg1);
 }
 
 void SettingsDialog::on_ShortCuts_clicked()
@@ -422,7 +422,7 @@ void SettingsDialog::populate() {
  //UI
         ui->checkBox_main_position_save_on_exit->setChecked(tmp_settings.save_main_window_position_on_exit);
         ui->checkBox_measure_position_save_on_exit->setChecked(tmp_settings.save_measure_window_position_on_exit);
-        ui->language->setText(tmp_settings.language);
+        ui->ComboBox_language->setCurrentText(tmp_settings.language);
 //---------SERIAL---------
         ui->serialPortInfoListBox->setCurrentText(tmp_settings.serial.portName);
         ui->comboBox_datasource->setCurrentIndex(static_cast<int>(tmp_settings.datasource));
@@ -454,7 +454,7 @@ void SettingsDialog::pullFromUi()
    tmp_settings.save_main_window_position_on_exit=ui->checkBox_main_position_save_on_exit->isChecked();
    qDebug()<<"pull save_main_window_position_on_exit " << tmp_settings.save_main_window_position_on_exit;
    tmp_settings.save_measure_window_position_on_exit=ui->checkBox_measure_position_save_on_exit->isChecked();
-   tmp_settings.language=ui->language->text();
+   tmp_settings.language = ui->ComboBox_language->currentText();
 
    //------------------SERIAL------------
    tmp_settings.serial.portName = ui->serialPortInfoListBox->currentText();

--- a/SettingsDialog.h
+++ b/SettingsDialog.h
@@ -37,8 +37,6 @@ public:
     bool document_saved = false;
     QString units;  //*
     double units_scale;
-    QString language;
-    QString language_tmp;
     QString directory_save_dxf; //*
     QString directory_save_data;//*
     //shortcuts
@@ -108,7 +106,7 @@ private:
 signals:
     void signal_scene(void);
     void signal_reconnect(void);
-    void signal_retranslate (void);
+    void languageChanged(const QString &language);
     //void documentModifiedChanged(bool newValue);
 
 };

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
     qDebug() << "serial port je" << port ;
     if (loadedSettings.datasource == DataSource::Serial && port.trimmed().isEmpty()) {
         SettingsDialog dlg(&mainwindow, settingsManager, serial_mng);
+        QObject::connect(&dlg, &SettingsDialog::languageChanged,
+                         &mainwindow, &MainWindow::onLanguageChanged);
         dlg.setSettings(loadedSettings);
         if (dlg.exec() == QDialog::Accepted) {
             settingsManager->updateSettings(dlg.result());

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -5,6 +5,8 @@
 #include <QFileDialog>     //save dxf
 #include <QDir>
 #include <QtMath>
+#include <QApplication>
+#include <QCoreApplication>
 #include "3rdparty/dxflib/src/dl_dxf.h"
 
 #include "appmanager.h"
@@ -919,12 +921,29 @@ void MainWindow::on_actionSetup_triggered(bool /*checked*/)
 
     qDebug()<<"on_actionSetup_triggered";
     SettingsDialog dlg(this, sm, appManager()->serialManager());
-        dlg.setSettings(sm->currentSettings());      // KOPIE do dialogu
+    connect(&dlg, &SettingsDialog::languageChanged,
+            this, &MainWindow::onLanguageChanged);
+    dlg.setSettings(sm->currentSettings());      // KOPIE do dialogu
 
-        if (dlg.exec() == QDialog::Accepted) {
-            qDebug()<<"ACCEPT";
-            sm->updateSettings(dlg.result());        // commit uvnitř SettingsManageru
-        }
+    if (dlg.exec() == QDialog::Accepted) {
+        qDebug()<<"ACCEPT";
+        sm->updateSettings(dlg.result());        // commit uvnitř SettingsManageru
+    }
+}
+
+void MainWindow::onLanguageChanged(const QString &language)
+{
+    qApp->removeTranslator(&translator);
+    qApp->removeTranslator(&guitranslator);
+
+    const QString base = language.toLower();
+    const QString appDir = QCoreApplication::applicationDirPath();
+    if (translator.load(appDir + "/translations/" + base + ".qm"))
+        qApp->installTranslator(&translator);
+    if (guitranslator.load(appDir + "/translations/qtbase_" + base + ".qm"))
+        qApp->installTranslator(&guitranslator);
+
+    ui->retranslateUi(this);
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -126,6 +126,7 @@ public slots:
     void setup_scene ();
     //void retranslate();
    // void handleDocumentModifiedChanged(bool newValue);
+    void onLanguageChanged(const QString &language);
 
 private:
     void initActions();


### PR DESCRIPTION
## Summary
- allow changing application language immediately from settings
- propagate language changes to main window via new signal

## Testing
- `qmake` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0452c514c8328859917031c504c38