### PR TITLE
Add helper for listing shapes with details

### DIFF
--- a/shapemanager.cpp
+++ b/shapemanager.cpp
@@ -1,5 +1,6 @@
 #include "shapemanager.h"
 #include <QDebug>
+#include <QRectF>
 
 ShapeManager::ShapeManager(QObject* parent)
     : QObject(parent)
@@ -35,9 +36,33 @@ void ShapeManager::deleteLastShape()
 void ShapeManager::printlistitems()
 {
     qDebug() << "printlistitems";
+    int index = 0;
     for (GraphicsItems* item : this->getShapes()) {
-        qDebug() << item->typeName();
+        qDebug().noquote() << index++ << ": " << shapeInfo(item);
     }
+}
+
+void ShapeManager::printShapesInfo() const
+{
+    int index = 0;
+    for (const GraphicsItems* item : shapes_) {
+        qDebug().noquote() << index++ << ": " << shapeInfo(item);
+    }
+}
+
+QString ShapeManager::shapeInfo(const GraphicsItems* item) const
+{
+    if (!item)
+        return QString("<null>");
+
+    QRectF rect = item->boundingRect();
+    return QString("%1 [x:%2 y:%3 w:%4 h:%5 fin:%6]")
+            .arg(item->typeName())
+            .arg(rect.x())
+            .arg(rect.y())
+            .arg(rect.width())
+            .arg(rect.height())
+            .arg(item->finished ? "true" : "false");
 }
 
 void ShapeManager::startShape(GraphicsItems* shape)

--- a/shapemanager.h
+++ b/shapemanager.h
@@ -5,6 +5,7 @@
 #include <QVector>
 #include <QGraphicsItem>
 #include <QPointF>
+#include <QString>
 #include "GraphicsItems.h"
 #include <memory>
 
@@ -20,6 +21,7 @@ public:
     void clear();
     void deleteLastShape();
     void printlistitems(void);
+    void printShapesInfo() const;
 
     // nový API pro tvorbu složitějších tvarů
     void startShape(GraphicsItems* shape);
@@ -32,6 +34,8 @@ signals:
 private:
     QVector<GraphicsItems*> shapes_;
     GraphicsItems* currentShape_ = nullptr;
+
+    QString shapeInfo(const GraphicsItems* item) const;
 };
 
 #endif // SHAPEMANAGER_H


### PR DESCRIPTION
## Summary
- add `shapeInfo` helper for descriptive info about individual shapes
- expose `printShapesInfo` and enhance `printlistitems` to show shape details

## Testing
- `qmake digitizer2.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b6c362708328af8816ae9b0f0750