### PR TITLE
Refactor measurement dialog handling

### DIFF
--- a/MeasureDialog.cpp
+++ b/MeasureDialog.cpp
@@ -21,6 +21,8 @@ MeasureDialog::MeasureDialog(SettingsManager* sm, QWidget* parent)
 {
     ui->setupUi(this);
     Q_ASSERT(settingsManager_);
+    set_color(Qt::black);
+    set_value(0);
 }
 
 MeasureDialog::~MeasureDialog()
@@ -107,4 +109,32 @@ void MeasureDialog::set_color(QColor color)
     auto palette = ui->lcdNumber->palette();
     palette.setColor(QPalette::WindowText, color);
     ui->lcdNumber->setPalette(palette);
+}
+
+void MeasureDialog::updatePosition(QPointF pos)
+{
+    if (mode == 1) {
+        const auto& st = settingsManager_->currentSettings();
+        double dist = mmToUnits(std::hypot(start_position.x() - pos.x(),
+                                           start_position.y() - pos.y()),
+                                 st.units);
+        set_value(dist);
+    } else if (mode == 0) {
+        set_value(0);
+    }
+}
+
+void MeasureDialog::toggleMode(QPointF pos)
+{
+    mode++;
+    if (mode >= 3) mode = 1;
+
+    if (mode == 1) {
+        set_color(Qt::red);
+        start_position = pos;
+        set_value(0);
+    } else if (mode == 2) {
+        set_color(Qt::green);
+        updatePosition(pos);
+    }
 }

--- a/MeasureDialog.h
+++ b/MeasureDialog.h
@@ -21,12 +21,14 @@ class MeasureDialog : public QDialog
 public:
     explicit MeasureDialog(SettingsManager* sm, QWidget* parent = nullptr);
     ~MeasureDialog();
-    int mode;  // 0-nic 1-zacatek mereni 2-zmrazeni
+    int mode = 0;  // 0-nic 1-zacatek mereni 2-zmrazeni
     QPointF start_position;
 
 public slots:
     void set_value(double value);      // units are read from SettingsManager
     void set_color(QColor color);
+    void updatePosition(QPointF pos);
+    void toggleMode(QPointF pos);
 
 protected:
     void showEvent(QShowEvent* e) override;

--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -59,6 +59,7 @@ void AppManager::setAngles(double alfa, double beta, int index)
 
     if (endPointBefore_ != endPointArm2_) {
         emit armsUpdated(Arm1Angle_, Arm2Angle_, endPointArm1_, endPointArm2_);
+        emit positionChanged(endPointArm2_);
         qDebug() << "AppManager::setAngles armsUpdated" << alfa_ << beta_ << endPointArm1_ << endPointArm2_;
     }
 
@@ -179,21 +180,7 @@ void AppManager::addPointtoShapeManager()
 
 void AppManager::addPointtoMeasuru()
 {
-    measure_->mode++;
-    if (measure_->mode >= 3) measure_->mode = 1;
-
-    if (measure_->mode == 0){
-        measure_->set_color(Qt::black);
-    }
-    if (measure_->mode == 1)
-    {
-        measure_->set_color(Qt::red);
-        measure_->start_position = endPointArm2_;
-    }
-    if (measure_->mode == 2) {
-        measure_->set_color(Qt::green);
-    }
-    emit armsUpdated(Arm1Angle_, Arm2Angle_, endPointArm1_, endPointArm2_);
+    emit measureToggled(endPointArm2_);
 }
 
 void AppManager::onShapesChanged()
@@ -216,11 +203,6 @@ void AppManager::setScene(QGraphicsScene *scene)
 {
     scene_ = scene;
     onShapesChanged();
-}
-
-void AppManager::setMeasure(MeasureDialog *measure)
-{
-    measure_ = measure;
 }
 
 void AppManager::setSettingsManager(SettingsManager* m)

--- a/appmanager.h
+++ b/appmanager.h
@@ -9,8 +9,6 @@
 #include "shapemanager.h"
 #include "settings.h"          // kvůli struct Settings
 #include "settingsmanager.h"
-#include "MeasureDialog.h"
-
 #pragma once
 
 class SerialManager; // forward deklarace
@@ -74,7 +72,6 @@ public:
     void cancelCurrentAction();
     void addpointfrommainwindow(void);
     void setScene(QGraphicsScene* scene);
-    void setMeasure (MeasureDialog* measure);
     void addPointtoMeasuru(void);
     void addPointtoShapeManager(void);
     void addPolylinetoShapeManager(void);
@@ -86,6 +83,8 @@ public:
 signals:
     // stávající signály
     void armsUpdated(double arm1Angle, double arm2Angle, QPointF endPointArm1_, QPointF endPointArm2_ );
+    void positionChanged(QPointF pos);
+    void measureToggled(QPointF pos);
     void modeAddPointChanged (AddPointMode newmode);
     void modeContiChanged(ContiMode mode);
     void sceneModified(QPointF endarm2);
@@ -103,7 +102,6 @@ private:
     Settings        settings_;                          // cache aktuálních settings
     SettingsManager* settingsManager_ = nullptr;        // ukazatel na settings manager
     SerialManager*   serialmanager_         = nullptr;         // ← ukazatel na SerialManager
-    MeasureDialog*  measure_ = nullptr;
 
     double Arm1Angle_{};
     double Arm2Angle_{};

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -902,30 +902,6 @@ void MainWindow::on_actionadd_point_triggered()
     appManager()->addpointfrommainwindow();
 }
 
-void MainWindow::show_measure_value(double Arm1Angle, double Arm2Angle,QPointF endPointArm1,QPointF endPointArm2)
-{
-
-
-    Q_UNUSED(Arm1Angle);
-    Q_UNUSED(Arm2Angle);
-    Q_UNUSED(endPointArm1);
-    if (!measure) return;
-    if  (measure->mode==1)
-    {
-        double distance;
-        const auto& st = settingsManager_->currentSettings();
-        distance = mmToUnits(qSqrt(qPow(measure->start_position.x() - endPointArm2.x(), 2) +
-                                   qPow(measure->start_position.y() - endPointArm2.y(), 2)),
-                              st.units);
-        measure->set_value(distance);
-    }
-    else if (measure->mode==0)
-    {
-        measure->set_value(0);
-    }
-}
-
-
 
 void MainWindow::on_actionSetup_triggered(bool /*checked*/)
 {
@@ -1019,6 +995,11 @@ void MainWindow::onAddPointModeChanged(AddPointMode mode)
         if (!measure) {
             measure = new MeasureDialog(appManager()->settingsManager(), this);
             measure->setAttribute(Qt::WA_DeleteOnClose, true);
+
+            connect(appManager(), &AppManager::positionChanged,
+                    measure, &MeasureDialog::updatePosition);
+            connect(appManager(), &AppManager::measureToggled,
+                    measure, &MeasureDialog::toggleMode);
 
             // Jakmile se dialog zavře (OK/Cancel/křížek), vrať režim do None
             connect(measure, &QDialog::finished, this, [this](int){

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -64,7 +64,6 @@ public:
     QElapsedTimer elapsedtimer;  //mereni casu
     bool shortcutPressed(const QString &shortcutStr, QKeyEvent *keyEvent);
     void handleCalibrateButtonClicked(bool checked);
-    void show_measure_value(double Arm1Angle, double Arm2Angle,QPointF endPointArm1,QPointF endPointArm2) ;
     QGraphicsLineItem* arm1 = nullptr;  //rameno 1
     QGraphicsLineItem* arm2 = nullptr;  //rameno 2
     QGraphicsEllipseItem *base;
@@ -73,7 +72,6 @@ public:
     QTranslator translator;
     QTranslator guitranslator;
     QStringList languages;
-    QMetaObject::Connection measureConn_;
 
 
 private:


### PR DESCRIPTION
## Summary
- Emit new `positionChanged` and `measureToggled` signals from `AppManager`
- Move measuring logic into `MeasureDialog` with slots for position updates and mode toggling
- Connect `AppManager` signals to `MeasureDialog` when opening the dialog in `MainWindow`

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1694d70188328bd7fa54ed8027641