### PR TITLE
Delay polyline creation until first point

### DIFF
--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -86,15 +86,13 @@ void AppManager::setAngles(double alfa, double beta, int index)
 
 void AppManager::setAddPointMode(AddPointMode mode) {
     if (mode == currentAddPointMode_) return;
+
+    if (currentAddPointMode_ == AddPointMode::Polyline && mode != AddPointMode::Polyline) {
+        shapeManager_.finishCurrent();
+    }
+
     currentAddPointMode_ = mode;
     qDebug() << "nastaven mode "  << modeAddPointToString(mode);
-    if (currentAddPointMode_ == AddPointMode::Polyline)  //prvni bod do polyline
-    {
-        auto *pl = new mypolyline();
-        scene_->addItem(pl);
-        shapeManager_.startShape(pl);
-        shapeManager_.appendToCurrent(endPointArm2_);
-    }
     emit modeAddPointChanged(mode);
 }
 
@@ -145,6 +143,11 @@ void AppManager::addpointfrommainwindow(void)
             break;
         case AddPointMode::Polyline:
             qDebug() << "polyline add point";
+            if (!shapeManager_.hasCurrent()) {
+                auto *pl = new mypolyline();
+                scene_->addItem(pl);
+                shapeManager_.startShape(pl);
+            }
             shapeManager_.appendToCurrent(endPointArm2_);
             break;
         case AddPointMode::Measure:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -344,7 +344,7 @@ void GraphicsView::mousePressEvent(QMouseEvent *event)
             event->accept();
             return;
         } else if (event->button() == Qt::RightButton) {
-            mw->appManager()->finishCurrentShape();
+            mw->appManager()->cancelCurrentAction();
             event->accept();
             return;
         }
@@ -974,9 +974,22 @@ void MainWindow::onAddPointModeChanged(AddPointMode mode)
 {
     qDebug() << " onAddPointModeChanged" << appManager()->modeAddPointToString(mode);
     const bool on_measure = (mode == AddPointMode::Measure);
+    const bool on_polyline = (mode == AddPointMode::Polyline);
 
     // UI: update akce
     {
+        {
+            QSignalBlocker block_action_polyline(ui->actionAdd_polyline);
+            ui->actionAdd_polyline->setChecked(on_polyline);
+            ui->actionAdd_polyline->setText(on_polyline ? tr("End polyline") : tr("Add polyline"));
+            QKeySequence seq = appManager()->settingsManager()->currentSettings().shortcuts.map
+                                 .value(QStringLiteral("action.polyline"));
+            QString shortcut = seq.toString(QKeySequence::PortableText);
+            ui->actionAdd_polyline->setToolTip(on_polyline
+                ? tr("konec polyline (%1)").arg(shortcut)
+                : tr("Přidat polyline (%1)").arg(shortcut));
+        }
+
         QSignalBlocker block_action_measure(ui->actionMeasure);
         ui->actionMeasure->setChecked(on_measure);
         ui->actionMeasure->setText(on_measure ? tr("Konec měření") : tr("Měření"));

--- a/shapemanager.cpp
+++ b/shapemanager.cpp
@@ -91,3 +91,8 @@ void ShapeManager::finishCurrent()
         emit shapesChanged();
     }
 }
+
+bool ShapeManager::hasCurrent() const
+{
+    return currentShape_ != nullptr;
+}

--- a/shapemanager.h
+++ b/shapemanager.h
@@ -27,6 +27,7 @@ public:
     void startShape(GraphicsItems* shape);
     void appendToCurrent(const QPointF& point);
     void finishCurrent();
+    bool hasCurrent() const;
 
 signals:
     void shapesChanged();


### PR DESCRIPTION
## Summary
- Start a new polyline only when the first point is added
- Finalize polyline when leaving polyline mode
- Keep UI in sync when polyline mode is cancelled

## Testing
- `qmake && make -j4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19593bf2c8328aa85f3a36f066bfb