### PR TITLE
Add start marker and automatic closing for polyline

### DIFF
--- a/GraphicsItems.cpp
+++ b/GraphicsItems.cpp
@@ -166,14 +166,17 @@ void mypolyline::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
     painter->drawLine (10,-10,-10,10);
     painter->drawPolyline(*mypolygon);
 
+    // spojnice posledního a prvního bodu během kreslení
+    if (mypolygon->count() > 1 && !finished) {
+        painter->drawLine(mypolygon->last(), mypolygon->first());
+    }
+
+    // zvýraznění posledního segmentu při výběru
     if (mypolygon->count()>1 and isSelected())
     {
-    //QPen temppen=QPen(Qt::red) ;
-    //temppen.setCapStyle(Qt::RoundCap);
-    //temppen.setWidth(6);
-    //painter->setPen(temppen);
-    painter->drawLine (mypolygon->at(mypolygon->count()-1).x(),mypolygon->at(mypolygon->count()-1).y(),mypolygon->at(mypolygon->count()-2).x(),mypolygon->at(mypolygon->count()-2).y());
-    painter->setPen(pen);
+        painter->drawLine(mypolygon->at(mypolygon->count()-1),
+                          mypolygon->at(mypolygon->count()-2));
+        painter->setPen(pen);
     }
 
 /*
@@ -184,6 +187,11 @@ void mypolyline::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
     painter->drawRect(m_boundingRect);
     painter->setPen(pen);
 */
+    // označení začátku polyline
+    if (!mypolygon->isEmpty()) {
+        painter->drawEllipse(mypolygon->first(), 5, 5);
+    }
+
     if (hoveredSegmentIndex >= 0 && isSelected() ) {
             painter->setPen(QPen(Qt::red, 30));
             painter->drawLine(mypolygon->at(hoveredSegmentIndex),

--- a/shapemanager.cpp
+++ b/shapemanager.cpp
@@ -86,6 +86,12 @@ void ShapeManager::appendToCurrent(const QPointF& point)
 void ShapeManager::finishCurrent()
 {
     if (currentShape_) {
+        if (auto pl = dynamic_cast<mypolyline*>(currentShape_)) {
+            if (pl->mypolygon && pl->mypolygon->size() > 1) {
+                pl->addPointToShape(pl->mypolygon->first());
+            }
+        }
+
         currentShape_->finished = true;
         currentShape_ = nullptr;
         emit shapesChanged();


### PR DESCRIPTION
## Summary
- draw a start marker for polylines and preview closing line during creation
- close polylines by joining last point to the start when finishing

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19ecbeb14832897500a27134a627b