### PR TITLE
Clear shapes via ShapeManager when starting new file

### DIFF
--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -171,6 +171,11 @@ void AppManager::finishCurrentShape()
     setAddPointMode(AddPointMode::None);
 }
 
+void AppManager::clearShapeManager()
+{
+    shapeManager_.clear();
+}
+
 void AppManager::addPointtoShapeManager()
 {
     lastpoint = endPointArm2_;

--- a/appmanager.h
+++ b/appmanager.h
@@ -76,6 +76,7 @@ public:
     void addPointtoShapeManager(void);
     void addPolylinetoShapeManager(void);
     void finishCurrentShape();
+    void clearShapeManager();
 
     double distance;
     QPointF lastpoint;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -590,28 +590,16 @@ void MainWindow::on_actionNew_file_triggered()
         }
         if (ret==QMessageBox::Discard or (ret==QMessageBox::Save and settings.document_saved==true))
         {
-            for (QGraphicsItem* item : scene->items()) {
-                    if (auto fm = dynamic_cast<GraphicsItems*>(item)) {
-                        if (fm->scene()) {
-                            fm->scene()->removeItem(fm);
-                        }
-                    }
-                }
+            appManager()->clearShapeManager();
             settings.document_modified=false;
             ui->actionSave_dxf->setEnabled(false);
         }
     }
     else
     {
-        for (QGraphicsItem* item : scene->items()) {
-                if (auto fm = dynamic_cast<GraphicsItems*>(item)) {
-                    if (fm->scene()) {
-                        fm->scene()->removeItem(fm);
-                    }
-                }
-            }
-    settings.document_modified=false;
-    ui->actionSave_dxf->setEnabled(false);
+        appManager()->clearShapeManager();
+        settings.document_modified=false;
+        ui->actionSave_dxf->setEnabled(false);
     }
 
 }

--- a/shapemanager.cpp
+++ b/shapemanager.cpp
@@ -22,6 +22,7 @@ const QVector<GraphicsItems*>& ShapeManager::getShapes() const
 void ShapeManager::clear()
 {
     shapes_.clear();
+    currentShape_ = nullptr;
     emit shapesChanged();
 }
 


### PR DESCRIPTION
## Summary
- Clear ShapeManager and reset current shape on new file action
- Expose `clearShapeManager` in `AppManager`
- Use ShapeManager to remove drawing items instead of wiping the scene

## Testing
- `qmake -v` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a12ade2c8328a5b8a07748019f4c