### PR TITLE
Ulož první bod hned při spuštění polyline

### DIFF
--- a/GraphicsItems.cpp
+++ b/GraphicsItems.cpp
@@ -127,6 +127,7 @@ void mypolyline::addPointToShape(const QPointF& point)
     qDebug() << "pridavam bod do mypolyline " << point ;
     prepareGeometryChange();
     mypolygon->append(point);
+    update();
     //m_boundingRect=QRectF(bounding_min_max());
 }
 

--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -97,6 +97,17 @@ void AppManager::setAddPointMode(AddPointMode mode) {
 
     currentAddPointMode_ = mode;
     qDebug() << "nastaven mode "  << modeAddPointToString(mode);
+
+    if (mode == AddPointMode::Polyline) {
+        if (!shapeManager_.hasCurrent()) {
+            auto *pl = new mypolyline();
+            scene_->addItem(pl);
+            shapeManager_.startShape(pl);
+            shapeManager_.appendToCurrent(endPointArm2_);
+            lastpoint = endPointArm2_;
+        }
+    }
+
     emit modeAddPointChanged(mode);
 }
 
@@ -147,12 +158,9 @@ void AppManager::addpointfrommainwindow(void)
             break;
         case AddPointMode::Polyline:
             qDebug() << "polyline add point";
-            if (!shapeManager_.hasCurrent()) {
-                auto *pl = new mypolyline();
-                scene_->addItem(pl);
-                shapeManager_.startShape(pl);
+            if (shapeManager_.hasCurrent()) {
+                shapeManager_.appendToCurrent(endPointArm2_);
             }
-            shapeManager_.appendToCurrent(endPointArm2_);
             break;
         case AddPointMode::Measure:
             qDebug() << "case measure add point";


### PR DESCRIPTION
## Summary
- Při zapnutí režimu polyline se hned vytvoří nový objekt a uloží první bod.
- Přidávání bodů polyline se zjednodušilo, body se jen přidávají do již existujícího objektu.
- Aktualizace polyline po každém přidání bodu kvůli okamžitému vykreslení spojnice na první bod.

## Testing
- `qmake digitizer2.pro` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2143327b08328a106e19891f61a7c