### PR TITLE
Initialize alfa/beta offsets in settings

### DIFF
--- a/settings.h
+++ b/settings.h
@@ -112,8 +112,8 @@ struct Settings {
     double arm1_length;
     double arm2_length;
     double auto_step;
-    double alfa_offset;
-    double beta_offset;
+    double alfa_offset = 0;
+    double beta_offset = 0;
     QString directory_save_dxf;
     QString directory_save_data;
     bool document_modified;

--- a/settingsmanager.cpp
+++ b/settingsmanager.cpp
@@ -24,6 +24,7 @@ SettingsManager::SettingsManager(QObject* parent)
     current_.arms_pen->setWidth(3);
     current_.arms_pen->setCapStyle(Qt::RoundCap);
     current_.arms_pen->setCosmetic(true);
+    saveToStore(current_, false);
     emit settingsChanged(current_);
     emit shortcutsChanged(current_.shortcuts);
 


### PR DESCRIPTION
## Summary
- init alfa_offset and beta_offset to zero
- persist default offsets to settings on startup

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b5f270f08328a6e08ff89f074711