### PR TITLE
Add calibration mode handling

### DIFF
--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -61,6 +61,10 @@ void AppManager::setAngles(double alfa, double beta, int index)
     endPointArm1_ = QPointF(x_value_,  y_value_);
     endPointArm2_ = QPointF(x_value2_, y_value2_);
 
+    if (currentAddPointMode_ == AddPointMode::Calibrate) {
+        emit calibrationAngles(Arm1Angle_, Arm2Angle_);
+    }
+
     if (endPointBefore_ != endPointArm2_) {
         emit armsUpdated(Arm1Angle_, Arm2Angle_, endPointArm1_, endPointArm2_);
         emit positionChanged(endPointArm2_);

--- a/appmanager.h
+++ b/appmanager.h
@@ -93,6 +93,7 @@ signals:
     void modeAddPointChanged (AddPointMode newmode);
     void modeContiChanged(ContiMode mode);
     void sceneModified(QPointF endarm2);
+    void calibrationAngles(double alfa, double beta);
 
     // --- Nové signály související se sériovým portem ---
     void serialOpened();                         // bez argumentu (matchuje SerialManager::opened())


### PR DESCRIPTION
## Summary
- enable calibration action and manage CalibrateWindow lifecycle based on AddPointMode
- emit calibrationAngles from AppManager during calibration
- hook calibration window to receive angle updates

## Testing
- `qmake 2>&1 | head -n 20` *(fails: command not found)*
- `make 2>&1 | head -n 20` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51f41477483289b10c3d6d4b5bf1d