### PR TITLE
Scale arms by reference radius

### DIFF
--- a/calibratewindow.cpp
+++ b/calibratewindow.cpp
@@ -841,7 +841,7 @@ void CalibrateWindow::on_calculate_clicked()
     for (int i=1;i<100;i++){
      CalibrationEngine engine(ui->doubleSpinBox_arm1_2->value(),ui->doubleSpinBox_arm2_2->value());
      engine.setAngles(angleslist);
-     engine.computeOpositPoints();
+     engine.computeOpositPoints(ui->doubleSpinBox_prumer->value()/2);
     //qDebug() << "vysledek z noveho engine arm1" << engine.getArm1() << "  arm2=" << engine.getArm2();
     qDebug() << " circlefit " << engine.getCircleRadius();
     double percent = 1;
@@ -898,7 +898,7 @@ void CalibrateWindow::on_calculate_clicked()
     {
     CalibrationEngine engine2(ui->doubleSpinBox_arm1->value(),ui->doubleSpinBox_arm2->value());
     engine2.setAngles(angleslist);
-    engine2.computeOpositPoints();
+    engine2.computeOpositPoints(ui->doubleSpinBox_prumer->value()/2);
     DeviationResult DeviationResult = computeMaxDeviation(angleslist,
                                              engine2.points(),
                                              engine2.getArm1(),
@@ -946,7 +946,7 @@ void CalibrateWindow::runDerivativeCalculation()
     for (int i = 1; i < 100; i++) {
         CalibrationEngine engine(ui->doubleSpinBox_arm1_2->value(), ui->doubleSpinBox_arm2_2->value());
         engine.setAngles(angleslist);
-        engine.computeOpositPoints();
+        engine.computeOpositPoints(ui->doubleSpinBox_prumer->value()/2);
         qDebug() << " circlefit " << engine.getCircleRadius();
         double percent = 1;
         DeviationResult DeviationResult = computeMaxDeviation(angleslist,
@@ -1005,7 +1005,7 @@ void CalibrateWindow::runGridCalculation()
     {
         CalibrationEngine engine2(ui->doubleSpinBox_arm1->value(),ui->doubleSpinBox_arm2->value());
         engine2.setAngles(angleslist);
-        engine2.computeOpositPoints();
+        engine2.computeOpositPoints(ui->doubleSpinBox_prumer->value()/2);
         DeviationResult DeviationResult = computeMaxDeviation(angleslist,
                                              engine2.points(),
                                              engine2.getArm1(),
@@ -1049,7 +1049,7 @@ void CalibrateWindow::runLeastSquaresCalculation()
     QApplication::setOverrideCursor(Qt::WaitCursor);
     CalibrationEngine engine(ui->doubleSpinBox_arm1_3->value(), ui->doubleSpinBox_arm2_3->value());
     engine.setAngles(angleslist);
-    engine.computeOpositPoints();
+    engine.computeOpositPoints(ui->doubleSpinBox_prumer->value()/2);
     CalibrationResult result = engine.optimizeArmsLeastSquares(ui->doubleSpinBox_prumer->value());
     ui->doubleSpinBox_arm1_3->setValue(result.adjustedArm1);
     ui->doubleSpinBox_arm2_3->setValue(result.adjustedArm2);

--- a/calibrationengine.cpp
+++ b/calibrationengine.cpp
@@ -1,5 +1,7 @@
 #include "calibrationengine.h"
 #include <QDebug>
+#include <QFile>
+#include <QTextStream>
 
 
 
@@ -32,7 +34,7 @@ const QVector<Angles>& CalibrationEngine::getAngles() const {
 }
 
 
-void CalibrationEngine::computeOpositPoints() {
+CalibrationResult CalibrationEngine::computeOpositPoints(double refRadius) {
     qDebug()<<"--computeOpositPoints--";
     double delta = arm1_ * 0.01; // 1% změna pro numerickou derivaci
 
@@ -128,6 +130,17 @@ void CalibrationEngine::computeOpositPoints() {
             }
             radius = rSum / N;
             circleRadius_ = radius;
+            if (refRadius > 0 && circleRadius_ > 0) {
+                double scale = refRadius / circleRadius_;
+                qDebug() << "scale factor" << scale;
+                QFile logFile("calibration_scale.log");
+                if (logFile.open(QIODevice::Append | QIODevice::Text)) {
+                    QTextStream ts(&logFile);
+                    ts << scale << "\n";
+                }
+                arm1_ *= scale;
+                arm2_ *= scale;
+            }
         }
 
 
@@ -184,6 +197,7 @@ void CalibrationEngine::computeOpositPoints() {
             maxErrorIndex_ = i;
         }
     }
+    return CalibrationResult{arm1_, arm2_};
 }
 
 

--- a/calibrationengine.h
+++ b/calibrationengine.h
@@ -74,7 +74,7 @@ public:
                                    int alfaMinOpositIndex);
     CalibrationResult optimizeArmsLeastSquares(double referenceDistance);
     void setAngles(const QVector<Angles>& angles);  //nastavi sadu uhlu
-    void computeOpositPoints();  //najde protilehle body a jejich indexy
+    CalibrationResult computeOpositPoints(double refRadius = 0.0);  //najde protilehle body a jejich indexy
 
     const QVector<CalibrationPoint>& points() const;
     double getArm1();


### PR DESCRIPTION
## Summary
- scale both arms according to reference circle radius
- log computed scale factor for later review
- pass user-provided radius to `computeOpositPoints`

## Testing
- `qmake -version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b67ffa847483289f4a359002416423