### PR TITLE
Ladicí dialog s informacemi o režimech a tvarů

### DIFF
--- a/InfoDialog.cpp
+++ b/InfoDialog.cpp
@@ -1,12 +1,26 @@
 #include <QDebug>
 #include "InfoDialog.h"
 #include "ui_InfoDialog.h"
+#include "appmanager.h"
 
-InfoDialog::InfoDialog(QWidget *parent) :
+InfoDialog::InfoDialog(AppManager* app, QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::InfoDialog)
+    ui(new Ui::InfoDialog),
+    app_(app)
 {
     ui->setupUi(this);
+    setWindowFlag(Qt::WindowStaysOnTopHint);
+
+    if (app_) {
+        connect(app_, &AppManager::modeAddPointChanged,
+                this, &InfoDialog::updateModes);
+        connect(app_, &AppManager::modeContiChanged,
+                this, &InfoDialog::updateModes);
+        connect(app_, &AppManager::shapesChanged,
+                this, &InfoDialog::updateCounts);
+        updateModes();
+        updateCounts();
+    }
 }
 
 InfoDialog::~InfoDialog()
@@ -36,4 +50,19 @@ void InfoDialog::on_close_clicked()
     qDebug()<<"Info on_close_clicked" ;
     this->close(); // Vyvolá closeEvent automaticky
 
+}
+
+void InfoDialog::updateModes()
+{
+    if (!app_) return;
+    ui->addmode_value->setText(app_->modeAddPointToString(app_->getAddPointMode()));
+    ui->contimode_value->setText(app_->modeContiToString(app_->getContiMode()));
+}
+
+void InfoDialog::updateCounts()
+{
+    if (!app_) return;
+    ui->num_points->setText(QString::number(app_->pointCount()));
+    ui->num_polylines->setText(QString::number(app_->polylineCount()));
+    ui->num_circles->setText(QString::number(app_->circleCount()));
 }

--- a/InfoDialog.h
+++ b/InfoDialog.h
@@ -3,6 +3,8 @@
 
 #include <QDialog>
 
+class AppManager;
+
 namespace Ui {
 class InfoDialog;
 }
@@ -12,17 +14,19 @@ class InfoDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit InfoDialog(QWidget *parent = nullptr);
+    explicit InfoDialog(AppManager* app, QWidget *parent = nullptr);
     ~InfoDialog();
     void set_num_of_points(int number);
     void closeEvent(QCloseEvent *event);
 
-
 private slots:
     void on_close_clicked();
+    void updateModes();
+    void updateCounts();
 
 private:
     Ui::InfoDialog *ui;
+    AppManager* app_ = nullptr;
 };
 
 #endif // MYINFO_H

--- a/InfoDialog.ui
+++ b/InfoDialog.ui
@@ -17,8 +17,8 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>20</y>
-     <width>91</width>
+     <y>80</y>
+     <width>120</width>
      <height>21</height>
     </rect>
    </property>
@@ -30,7 +30,111 @@
    <property name="geometry">
     <rect>
      <x>160</x>
+     <y>80</y>
+     <width>91</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_addmode">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
      <y>20</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Add mode</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="addmode_value">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>20</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_contimode">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>50</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Conti mode</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="contimode_value">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>50</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_num_polylines">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>110</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Polylines</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="num_polylines">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>110</y>
+     <width>91</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_num_circles">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>140</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Circles</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="num_circles">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>140</y>
      <width>91</width>
      <height>21</height>
     </rect>

--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -117,6 +117,10 @@ AddPointMode AppManager::getAddPointMode() const {
     return currentAddPointMode_;
 }
 
+ContiMode AppManager::getContiMode() const {
+    return currentContiMode_;
+}
+
 QString AppManager::modeAddPointToString(AddPointMode mode) {
     switch (mode) {
     case AddPointMode::None:      return "None";
@@ -219,6 +223,38 @@ void AppManager::onShapesChanged()
         //qDebug()<<"AppManager::onShapesChanged :" <<shape;
         scene_->addItem(shape);
     }
+
+    emit shapesChanged();
+}
+
+int AppManager::pointCount() const {
+    int count = 0;
+    for (auto* item : shapeManager_.getShapes()) {
+        if (dynamic_cast<mypoint*>(item)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+int AppManager::polylineCount() const {
+    int count = 0;
+    for (auto* item : shapeManager_.getShapes()) {
+        if (dynamic_cast<mypolyline*>(item)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+int AppManager::circleCount() const {
+    int count = 0;
+    for (auto* item : shapeManager_.getShapes()) {
+        if (dynamic_cast<mycircle*>(item)) {
+            ++count;
+        }
+    }
+    return count;
 }
 
 void AppManager::setScene(QGraphicsScene *scene)

--- a/appmanager.h
+++ b/appmanager.h
@@ -68,6 +68,7 @@ public:
     void setAddPointMode(AddPointMode mode);
     void setContiMode(ContiMode mode);
     AddPointMode getAddPointMode() const;
+    ContiMode getContiMode() const;
     QString modeAddPointToString(AddPointMode mode);
     QString modeContiToString(ContiMode mode);
     void cancelCurrentAction();
@@ -84,6 +85,9 @@ public:
 
     QPointF arm2EndPoint() const { return endPointArm2_; }
     GraphicsItems* currentShape() const { return shapeManager_.currentShape(); }
+    int pointCount() const;
+    int polylineCount() const;
+    int circleCount() const;
 
 signals:
     // stávající signály
@@ -94,6 +98,7 @@ signals:
     void modeContiChanged(ContiMode mode);
     void sceneModified(QPointF endarm2);
     void calibrateAnglesAdded(double alfaDeg, double betaDeg);
+    void shapesChanged();
 
     // --- Nové signály související se sériovým portem ---
     void serialOpened();                         // bez argumentu (matchuje SerialManager::opened())

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -611,7 +611,7 @@ void MainWindow::on_actionNew_file_triggered()
 
 void MainWindow::on_actionInfo_triggered()
 {
-    info = new InfoDialog(this);
+    info = new InfoDialog(appManager(), this);
 //    recalculate_info();  pocitala pocet prvku
     info->show();
 }


### PR DESCRIPTION
## Shrnutí
- Přidáno nové ladicí okno vždy navrchu s detaily o režimu přidávání bodů, kontinuálním režimu a počty tvarů.
- AppManager poskytuje počty bodů, polyline a kružnic a emituje signál při změně tvarů.
- Hlavní okno nyní otevírá InfoDialog s vazbou na AppManager.

## Testování
- `qmake digitizer2.pro` *(selhalo: command not found)*
- `make` *(selhalo: No targets specified and no makefile found)*


------
https://chatgpt.com/codex/tasks/task_e_68b82677978c8328ba6d50a5a331fe32