### PR TITLE
Add psapi library for Windows

### DIFF
--- a/InfoDialog.cpp
+++ b/InfoDialog.cpp
@@ -1,4 +1,8 @@
 #include <QDebug>
+#ifdef _WIN32
+#include <windows.h>
+#include <psapi.h>
+#endif
 #include "InfoDialog.h"
 #include "ui_InfoDialog.h"
 #include "appmanager.h"
@@ -21,6 +25,11 @@ InfoDialog::InfoDialog(AppManager* app, QWidget *parent) :
         updateModes();
         updateCounts();
     }
+
+    memoryTimer_ = new QTimer(this);
+    connect(memoryTimer_, &QTimer::timeout, this, &InfoDialog::updateMemory);
+    memoryTimer_->start(1000);
+    updateMemory();
 }
 
 InfoDialog::~InfoDialog()
@@ -65,4 +74,16 @@ void InfoDialog::updateCounts()
     ui->num_points->setText(QString::number(app_->pointCount()));
     ui->num_polylines->setText(QString::number(app_->polylineCount()));
     ui->num_circles->setText(QString::number(app_->circleCount()));
+}
+
+void InfoDialog::updateMemory()
+{
+#ifdef _WIN32
+    PROCESS_MEMORY_COUNTERS counters;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &counters, sizeof(counters))) {
+        ui->memory_value->setText(QString::number(counters.WorkingSetSize / 1024));
+    }
+#else
+    ui->memory_value->setText("N/A");
+#endif
 }

--- a/InfoDialog.h
+++ b/InfoDialog.h
@@ -2,6 +2,7 @@
 #define INFODIALOG_H
 
 #include <QDialog>
+#include <QTimer>
 
 class AppManager;
 
@@ -23,10 +24,12 @@ private slots:
     void on_close_clicked();
     void updateModes();
     void updateCounts();
+    void updateMemory();
 
 private:
     Ui::InfoDialog *ui;
     AppManager* app_ = nullptr;
+    QTimer* memoryTimer_ = nullptr;
 };
 
 #endif // MYINFO_H

--- a/InfoDialog.ui
+++ b/InfoDialog.ui
@@ -143,6 +143,32 @@
     <string/>
    </property>
   </widget>
+  <widget class="QLabel" name="label_memory">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>170</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Memory usage (KB)</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="memory_value">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>170</y>
+     <width>91</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+  </widget>
   <widget class="QPushButton" name="close">
    <property name="geometry">
     <rect>

--- a/digitizer2.pro
+++ b/digitizer2.pro
@@ -79,3 +79,5 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 
 RESOURCES += \
     resources.qrc
+
+win32: LIBS += -lpsapi


### PR DESCRIPTION
## Summary
- include psapi library for Windows build
- guard psapi header in InfoDialog
- include windows header before psapi to fix missing type errors
- show process memory usage in InfoDialog via psapi

## Testing
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*
- `apt-get install -y qt5-qmake qtbase5-dev` *(fails: Unable to locate package qt5-qmake)*
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b831d781008328980ce027157ab082