### PR TITLE
feat: toggleable zoom modes

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -7,6 +7,7 @@
 #include <QtGui>
 #include <QSerialPort>
 #include <QGraphicsView>
+#include <QShortcut>
 #include "settings.h"
 #include "appmanager.h" //musi byt
 
@@ -28,6 +29,7 @@ class GraphicsItems;
 class QKeyEvent;
 class QMouseEvent;
 enum class AddPointMode;
+enum class ZoomMode { All, Dynamic, User };
 
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
@@ -122,6 +124,7 @@ public slots:
     void Zoom_Dynamic();
     void Zoom_All();
     void Zoom_User();
+    void toggleZoomMode();
     void status_bar_print(QString,int);
     void setup_scene ();
     //void retranslate();
@@ -134,6 +137,8 @@ private:
 
     QMenu* ZoomMenu;
     CustomToolButton* ZoomToolButton;
+    ZoomMode zoomMode_ = ZoomMode::All;
+    QShortcut* zoomShortcut_ = nullptr;
 
     /*modbus*/
     //QModbusDataUnit readRequest() const;


### PR DESCRIPTION
## Summary
- add ZoomMode enum and shortcut-based toggling between dynamic and all zoom
- introduce USER zoom mode and update graphics view wheel to switch to it
- reuse existing manual icon for USER zoom and drop custom zoom_user resource
- refine zoom mode actions: checked state handling, user action, and shortcut setup

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96a4ec9708328ac59560cb0ffd33f