### PR TITLE
Show serial connection and manage toolbar icons

### DIFF
--- a/InfoDialog.cpp
+++ b/InfoDialog.cpp
@@ -23,8 +23,13 @@ InfoDialog::InfoDialog(AppManager* app, QWidget *parent) :
                 this, &InfoDialog::updateModes);
         connect(app_, &AppManager::shapesChanged,
                 this, &InfoDialog::updateCounts);
+        connect(app_, &AppManager::serialOpened,
+                this, &InfoDialog::onSerialOpened);
+        connect(app_, &AppManager::serialClosed,
+                this, &InfoDialog::onSerialClosed);
         updateModes();
         updateCounts();
+        updateConnectionStatus(app_->isSerialConnected());
     }
 
     if (auto mw = qobject_cast<MainWindow*>(parent)) {
@@ -95,4 +100,20 @@ QString InfoDialog::zoomModeToString(ZoomMode mode)
     default:
         return tr("Unknown");
     }
+}
+
+void InfoDialog::updateConnectionStatus(bool connected)
+{
+    ui->connection_value->setText(connected ? tr("Connected")
+                                           : tr("Disconnected"));
+}
+
+void InfoDialog::onSerialOpened()
+{
+    updateConnectionStatus(true);
+}
+
+void InfoDialog::onSerialClosed()
+{
+    updateConnectionStatus(false);
 }

--- a/InfoDialog.h
+++ b/InfoDialog.h
@@ -25,6 +25,9 @@ private slots:
     void updateModes();
     void updateCounts();
     void updateZoomMode(ZoomMode mode);
+    void updateConnectionStatus(bool connected);
+    void onSerialOpened();
+    void onSerialClosed();
 
 private:
     static QString zoomModeToString(ZoomMode mode);

--- a/InfoDialog.ui
+++ b/InfoDialog.ui
@@ -169,6 +169,32 @@
     <string/>
    </property>
   </widget>
+  <widget class="QLabel" name="label_connection">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>200</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Serial connection</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="connection_value">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>200</y>
+     <width>120</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Disconnected</string>
+   </property>
+  </widget>
   <widget class="QPushButton" name="close">
    <property name="geometry">
     <rect>

--- a/appmanager.cpp
+++ b/appmanager.cpp
@@ -384,6 +384,7 @@ void AppManager::logDataSetCount()
 
 void AppManager::onSerialOpened()
 {
+    serialConnected_ = true;
     qDebug() << "AppManager: opened -" << dataSourceToHuman();
     // pošli čitelnou hlášku ven (MainWindow -> statusbar)
     emit connectionNotice(tr("Připojeno: %1").arg(dataSourceToHuman()));
@@ -391,6 +392,7 @@ void AppManager::onSerialOpened()
 
 void AppManager::onSerialClosed()
 {
+    serialConnected_ = false;
     qDebug() << "AppManager: close -" << dataSourceToHuman();
     emit connectionNotice(tr("Odpojeno: %1").arg(dataSourceToHuman()));
     settings_.simulation.loggingEnabled = false;

--- a/appmanager.h
+++ b/appmanager.h
@@ -61,6 +61,7 @@ public:
     void closeSerial();
     void send(const QByteArray& data);
     QString dataSourceToHuman() const;           // pomocná human-readable hláška
+    bool isSerialConnected() const { return serialConnected_; }
 
     void setAngles(double alfa, double beta,int index);
     double getAlfa();
@@ -132,6 +133,7 @@ private:
     QTimer dataSetTimer_;
     int dataSetCount_ = 0;
     void logDataSetCount();
+    bool serialConnected_ = false;
 
 public slots:
     // zatím prázdné; ponecháno pro případné budoucí sloty

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -41,16 +41,12 @@ MainWindow::MainWindow(AppManager *app, QWidget *parent)
   connect(ui->actionDisconnect, &QAction::triggered, this,
           [this](bool) { appManager_->closeSerial(); });
   connect(appManager_, &AppManager::serialOpened, this,
-          [this]() { // stav ikony z appmanageru.
-            ui->actionConnect->setEnabled(false);
-            ui->actionDisconnect->setEnabled(true);
-          });
+          [this]() { updateSerialActions(true); });
   qDebug() << "konstruktoru 2";
-  connect(appManager_, &AppManager::serialClosed, this, [this]() {
-    ui->actionConnect->setEnabled(true);
-    ui->actionDisconnect->setEnabled(false);
-  });
+  connect(appManager_, &AppManager::serialClosed, this,
+          [this]() { updateSerialActions(false); });
   qDebug() << "konstruktoru 3";
+  updateSerialActions(appManager_->isSerialConnected());
   connect(ui->actionAdd_polyline, &QAction::toggled, this, [this](bool on) {
     if (on)
       appManager()->setAddPointMode(AddPointMode::Polyline);
@@ -125,6 +121,12 @@ MainWindow::MainWindow(AppManager *app, QWidget *parent)
 }
 
 MainWindow::~MainWindow() { delete ui; }
+
+void MainWindow::updateSerialActions(bool connected)
+{
+  ui->actionConnect->setEnabled(!connected);
+  ui->actionDisconnect->setEnabled(connected);
+}
 
 void MainWindow::closeEvent(QCloseEvent *event)
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -134,6 +134,7 @@ public slots:
 private:
   void initActions();
   void initMenu();
+  void updateSerialActions(bool connected);
 
   QMenu *ZoomMenu;
   CustomToolButton *ZoomToolButton;


### PR DESCRIPTION
## Summary
- Info dialog reaguje na otevření a zavření sériového portu pomocí nových slotů
- Main window sjednocuje logiku pro ikony Connect/Disconnect do `updateSerialActions`

## Testing
- `qmake -v` *(chyba: command not found)*
- `make` *(chyba: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9e5b5d88328927556dc1bcde9c7