### PR TITLE
Toggle continuous mode via ContiMode

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -119,7 +119,7 @@ MainWindow::MainWindow(AppManager *app, QWidget *parent)
 
   qDebug() << "konec konstruktoru";
   onAddPointModeChanged(AddPointMode::None); // vyplneni zkratek v tooltipu a podobne
-  onContiModeChanged(ContiMode::SinglePoint); // vyplni zkratky u conti a
+  onContiModeChanged(appManager()->getContiMode()); // vyplni zkratky u conti a
 
 
 }
@@ -631,11 +631,9 @@ void MainWindow::on_actionset_zero_triggered() {
 }
 
 void MainWindow::on_actionAuto_triggered() {
-  if (ui->actionAuto->isChecked()) {
-    ui->actionAuto->setIcon(QIcon(QStringLiteral(":/pic/auto.png")));
+  if (appManager()->getContiMode() == ContiMode::SinglePoint) {
     appManager()->setContiMode(ContiMode::Continous);
   } else {
-    ui->actionAuto->setIcon(QIcon(QStringLiteral(":/pic/manual.png")));
     appManager()->setContiMode(ContiMode::SinglePoint);
   }
 }
@@ -995,6 +993,9 @@ void MainWindow::onSettingsChanged(const Settings &s) {
 void MainWindow::onContiModeChanged(ContiMode mode) {
   const bool on_contimode = (mode == ContiMode::Continous);
   // mode continous
+  ui->actionAuto->setIcon(QIcon(on_contimode
+                                    ? QStringLiteral(":/pic/auto.png")
+                                    : QStringLiteral(":/pic/manual.png")));
   QKeySequence seq =
       appManager()->settingsManager()->currentSettings().shortcuts.map.value(
           QStringLiteral("action.continous"));

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -319,7 +319,7 @@
   </action>
   <action name="actionAuto">
    <property name="checkable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="icon">
     <iconset resource="resources.qrc">


### PR DESCRIPTION
## Summary
- toggle continuous mode based on current ContiMode instead of action's checked state
- update icon in onContiModeChanged and make auto action non-checkable
- initialize conti-mode icon from the current mode

## Testing
- `qmake && make -j4` *(fails: command not found)*
- `apt-get update >/tmp/apt-update.log && tail -n 20 /tmp/apt-update.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee557ae48328a9e421792a58e60b