### PR TITLE
Remove unused polyline helper

### DIFF
--- a/appmanager.h
+++ b/appmanager.h
@@ -76,9 +76,7 @@ public:
     void addpointfrommainwindow(void);
     void setScene(QGraphicsScene* scene);
     void addPointtoMeasuru(void);
-    void addPointtoShapeManager(void);
     void deleteLastPoint();
-    void addPolylinetoShapeManager(void);
     void finishCurrentShape();
     void clearShapeManager();
 

--- a/shapemanager.cpp
+++ b/shapemanager.cpp
@@ -74,7 +74,9 @@ void ShapeManager::startShape(GraphicsItems* shape)
 {
     if (!shape) return;
     currentShape_ = shape;
-    addShape(shape);
+    if (!shapes_.contains(shape)) {
+        addShape(shape);
+    }
 }
 
 void ShapeManager::appendToCurrent(const QPointF& point)


### PR DESCRIPTION
## Summary
- drop dead `addPolylinetoShapeManager` function from AppManager
- tidy up header accordingly
- unify point insertion via `addpointfrommainwindow` and reuse shapes through improved `ShapeManager::startShape`

## Testing
- `qmake digitizer2.pro` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bacfb68a588328af742589b27f8a06